### PR TITLE
ParkPlanner: fix laadprobleem + OSM/satelliet-kaarten

### DIFF
--- a/files/testfit/README.md
+++ b/files/testfit/README.md
@@ -8,6 +8,9 @@ rijstroken en metrics — geïnspireerd op TestFit's *Parking Solver*.
 
 ## Wat het doet
 
+- **Kaart-onderlaag** — plan bovenop **OpenStreetMap**, **satelliet** of **hybride**
+  (satelliet + labels) luchtbeelden. Zoek een adres/plaats (OSM Nominatim) en de
+  site wordt op die locatie geplaatst; de tegels lijnen uit met de site-geometrie.
 - **Site tekenen** — polygoon-tool met sleepbare hoekpunten en numerieke oppervlakte.
 - **Gebouwen / uitsluitingszones** — sleep rechthoeken die de solver respecteert.
 - **Automatische parkeergeneratie** — dubbel-belaste modules, live herberekend.
@@ -38,19 +41,25 @@ Alles draait client-side; er is geen backend en geen build-stap nodig.
 ## Architectuur
 
 Bewust **geen build-tooling** (past bij deze GitHub Pages-site). React, ReactDOM
-en `htm` zijn lokaal gevendord in `vendor/` en via een import-map gekoppeld, dus
-de app is volledig zelfstandig — geen runtime-CDN.
+en `htm` zijn lokaal gevendord in `vendor/` als klassieke UMD-scripts en via kleine
+ESM-shims geïmporteerd met **relatieve paden** — geen import-map en geen runtime-CDN.
+Daardoor boot de app ook op oudere browsers (ES-modules, geen import-maps vereist),
+met een foutmelding-overlay als er toch iets misgaat.
 
 ```
 files/testfit/
-├── index.html            # import-map + gevendorde <script>-tags
+├── index.html            # gevendorde <script>-tags + boot-foutoverlay
 ├── styles.css            # donkere CAD-achtige UI
 ├── vendor/               # React 18, ReactDOM, htm (UMD + ESM-shims)
 └── src/
     ├── geometry.js       # pure 2D-polygoongeometrie (offset, clip, hit-tests)
     ├── solver.js         # parkeer-solver + ADA-tabel + metrics
+    ├── basemap.js        # slippy-map tegels (OSM/Esri) + geocoding + geo↔meters
     └── app.js            # React-UI (htm) + imperatieve canvas-rendering
 ```
+
+De kaart-tegels (OpenStreetMap, Esri World Imagery) en geocoding (Nominatim) zijn
+de enige externe netwerkverzoeken; zonder internet werkt de rest gewoon door.
 
 `geometry.js` en `solver.js` zijn dependency-vrije, pure ES-modules en zijn
 los te testen met Node.

--- a/files/testfit/index.html
+++ b/files/testfit/index.html
@@ -2,29 +2,46 @@
 <html lang="nl">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <title>ParkPlanner — TestFit-kloon</title>
-  <meta name="description" content="Automatische parkeerplanner: teken een site, genereer live parkeervakken, rijstroken en metrics. Een open-source TestFit-kloon in React." />
+  <meta name="description" content="Automatische parkeerplanner: teken een site op OSM- of satellietkaarten, genereer live parkeervakken, rijstroken en metrics. Een open-source TestFit-kloon in React." />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🅿️</text></svg>" />
   <link rel="stylesheet" href="./styles.css" />
-  <!-- Vendored, self-contained dependencies (no runtime CDN needed). -->
+  <!-- Vendored dependencies as classic UMD scripts (globals). No import
+       maps and no runtime CDN, so the app boots on older browsers too. -->
   <script src="./vendor/react.production.min.js"></script>
   <script src="./vendor/react-dom.production.min.js"></script>
   <script src="./vendor/htm.js"></script>
-  <script type="importmap">
-    {
-      "imports": {
-        "react": "./vendor/react.mjs",
-        "react-dom/client": "./vendor/react-dom-client.mjs",
-        "htm": "./vendor/htm.mjs"
-      }
-    }
-  </script>
 </head>
 <body>
   <div id="root">
     <div class="boot">Bezig met laden van ParkPlanner…</div>
   </div>
+
+  <!-- Fail loudly instead of a silent blank/crash screen. -->
+  <script>
+    (function () {
+      var shown = false;
+      function fail(msg) {
+        if (shown) return; shown = true;
+        var r = document.getElementById('root');
+        if (r) r.innerHTML =
+          '<div class="boot" style="flex-direction:column;gap:10px;padding:24px;text-align:center">' +
+          '<div style="font-size:15px;color:#e6eaef">ParkPlanner kon niet laden</div>' +
+          '<div style="max-width:420px">' + (msg || '') + '</div>' +
+          '<button onclick="location.reload()" style="margin-top:8px;padding:8px 14px;background:#3b82f6;color:#fff;border:none;border-radius:6px;cursor:pointer">Opnieuw proberen</button>' +
+          '</div>';
+      }
+      window.addEventListener('error', function (e) {
+        if (e && e.target && e.target.tagName === 'SCRIPT') fail('Een scriptbestand kon niet geladen worden. Controleer je verbinding en probeer opnieuw.');
+      }, true);
+      window.addEventListener('unhandledrejection', function () { /* handled in-app */ });
+      // If React never mounted after a grace period, surface a hint.
+      window.__pp_boot = setTimeout(function () {
+        if (!document.querySelector('.app')) fail('De app is niet gestart. Werk je browser bij (iOS 12+/moderne browser) en probeer opnieuw.');
+      }, 6000);
+    })();
+  </script>
   <script type="module" src="./src/app.js"></script>
 </body>
 </html>

--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -1,13 +1,15 @@
 // ============================================================
 // app.js — ParkPlanner React UI (no build step; htm + React ESM)
 // ============================================================
-import React, { useReducer, useRef, useState, useEffect, useCallback, useMemo } from 'react';
-import { createRoot } from 'react-dom/client';
-import htm from 'htm';
+import React, { useReducer, useRef, useState, useEffect, useCallback, useMemo } from '../vendor/react.mjs';
+import { createRoot } from '../vendor/react-dom-client.mjs';
+import htm from '../vendor/htm.mjs';
 import { solveParking, computeMetrics, STALL_TYPES } from './solver.js';
 import {
   offsetPolygon, boundingBox, polygonCentroid, dist, pointInPolygon, rectPoly,
 } from './geometry.js';
+import * as basemap from './basemap.js';
+import { BASEMAPS, geocode } from './basemap.js';
 
 const html = htm.bind(React.createElement);
 
@@ -33,9 +35,12 @@ const DEFAULT_OBSTACLES = [
   rectPoly(60, 36, 36, 24), // building footprint, top-right
 ];
 
+// Geographic anchor for local origin (0,0). Default: Amsterdam Zuidas.
+const DEFAULT_GEO = { lat: 52.3390, lon: 4.8730 };
+
 // ---------- Document reducer + undo/redo ----------
 const initialDoc = {
-  site: DEFAULT_SITE, obstacles: DEFAULT_OBSTACLES,
+  site: DEFAULT_SITE, obstacles: DEFAULT_OBSTACLES, geo: DEFAULT_GEO,
   params: DEFAULT_PARAMS, orientationIndex: 0,
 };
 
@@ -83,11 +88,16 @@ function fitView(site, width, height, pad = 60) {
 
 // ---------- Rendering ----------
 function draw(ctx, opts) {
-  const { view, doc, result, layers, dpr, drawing, hover, selection, size } = opts;
+  const { view, doc, result, layers, dpr, drawing, hover, selection, size, basemapStyle } = opts;
   const { w2s } = makeTransform(view);
   ctx.save();
   ctx.scale(dpr, dpr);
   ctx.clearRect(0, 0, size.w, size.h);
+
+  // Basemap tiles (under everything)
+  if (basemapStyle && basemapStyle !== 'none') {
+    basemap.drawBasemap(ctx, { style: basemapStyle, geo: doc.geo, view, size, w2s });
+  }
 
   // Grid
   if (layers.grid) drawGrid(ctx, view, size);
@@ -217,6 +227,10 @@ function App() {
   const [selection, setSelection] = useState(null);
   const [result, setResult] = useState({ stalls: [], aisles: [], orientationCount: 0 });
   const [solving, setSolving] = useState(false);
+  const [basemapStyle, setBasemapStyle] = useState('none');
+  const [geoSearch, setGeoSearch] = useState('');
+  const [geoBusy, setGeoBusy] = useState(false);
+  const [geoMsg, setGeoMsg] = useState('');
 
   const wrapRef = useRef(null);
   const canvasRef = useRef(null);
@@ -226,16 +240,24 @@ function App() {
   const fittedRef = useRef(false);
   const renderRef = useRef(() => {}); // always points at the latest renderNow
 
-  // Resize handling + initial fit.
+  // Once mounted, cancel the index.html boot-failure fallback and let
+  // the tile loader trigger redraws as tiles arrive.
+  useEffect(() => {
+    if (window.__pp_boot) { clearTimeout(window.__pp_boot); window.__pp_boot = null; }
+    basemap.setRedraw(() => renderRef.current());
+  }, []);
+
+  // Resize handling + initial fit. DPR capped at 2 to avoid huge canvas
+  // backing stores that can crash mobile Safari on hi-DPI screens.
   useEffect(() => {
     const el = wrapRef.current;
     const ro = new ResizeObserver(() => {
       const r = el.getBoundingClientRect();
       sizeRef.current = { w: r.width, h: r.height };
       const canvas = canvasRef.current;
-      const dpr = window.devicePixelRatio || 1;
-      canvas.width = r.width * dpr;
-      canvas.height = r.height * dpr;
+      const dpr = Math.min(2, window.devicePixelRatio || 1);
+      canvas.width = Math.round(r.width * dpr);
+      canvas.height = Math.round(r.height * dpr);
       canvas.style.width = r.width + 'px';
       canvas.style.height = r.height + 'px';
       if (!fittedRef.current && r.width > 0) {
@@ -267,11 +289,11 @@ function App() {
     const ctx = canvas.getContext('2d');
     draw(ctx, {
       view, doc, result, layers,
-      dpr: window.devicePixelRatio || 1,
+      dpr: Math.min(2, window.devicePixelRatio || 1),
       drawing, hover, selection, size: sizeRef.current,
-      showHandles: tool === 'select',
+      showHandles: tool === 'select', basemapStyle,
     });
-  }, [view, doc, result, layers, drawing, hover, selection, tool]);
+  }, [view, doc, result, layers, drawing, hover, selection, tool, basemapStyle]);
 
   renderRef.current = renderNow;
   useEffect(() => { renderNow(); }, [renderNow]);
@@ -474,6 +496,31 @@ function App() {
     setTimeout(fitToSite, 0);
   };
 
+  // Re-anchor the plan so the site centroid sits at a geographic point.
+  const centerOnLatLon = (lat, lon) => {
+    const c = polygonCentroid(doc.site);
+    const cosLat = Math.cos((lat * Math.PI) / 180);
+    const geo = { lat: lat + c.y / 111320, lon: lon - c.x / (111320 * cosLat) };
+    dispatch({ type: 'COMMIT', updater: (d) => ({ ...d, geo }) });
+    setTimeout(fitToSite, 0);
+  };
+  const doGeocode = async () => {
+    const q = geoSearch.trim();
+    if (!q) return;
+    setGeoBusy(true); setGeoMsg('');
+    try {
+      const hit = await geocode(q);
+      if (!hit) { setGeoMsg('Niet gevonden'); }
+      else {
+        centerOnLatLon(hit.lat, hit.lon);
+        if (basemapStyle === 'none') setBasemapStyle('satellite');
+        setGeoMsg(hit.label.split(',').slice(0, 3).join(', '));
+      }
+    } catch (err) {
+      setGeoMsg('Zoeken mislukt (netwerk/CORS)');
+    } finally { setGeoBusy(false); }
+  };
+
   // ---------- Render UI ----------
   const hintText = {
     site: 'Klik om punten te plaatsen · klik het eerste punt of dubbelklik om te sluiten · Esc annuleert',
@@ -506,6 +553,20 @@ function App() {
       </div>
 
       <div className="panel left">
+        <div className="section">
+          <h3>Kaart (onderlaag)</h3>
+          <select className="preset" style=${{ marginBottom: '10px' }}
+            value=${basemapStyle} onChange=${(e) => setBasemapStyle(e.target.value)}>
+            ${Object.entries(BASEMAPS).map(([k, m]) => html`<option key=${k} value=${k}>${m.label}</option>`)}
+          </select>
+          <form onSubmit=${(e) => { e.preventDefault(); doGeocode(); }} className="geo-form">
+            <input type="text" placeholder="Zoek adres of plaats…" value=${geoSearch}
+              onChange=${(e) => setGeoSearch(e.target.value)} />
+            <button type="submit" className="btn" disabled=${geoBusy}>${geoBusy ? '…' : 'Ga'}</button>
+          </form>
+          ${geoMsg && html`<div className="geo-msg">${geoMsg}</div>`}
+          <div className="geo-coord">📍 ${doc.geo.lat.toFixed(5)}, ${doc.geo.lon.toFixed(5)}</div>
+        </div>
         <div className="section">
           <h3>Lagen</h3>
           ${layerRow('grid', 'Raster', '#3b4453', layers, setLayers)}
@@ -540,6 +601,8 @@ function App() {
           <span>·</span>
           <span>${solving ? 'rekenen…' : 'live'}</span>
         </div>
+        ${basemapStyle !== 'none' && BASEMAPS[basemapStyle].attribution && html`
+          <div className="attrib">${BASEMAPS[basemapStyle].attribution}</div>`}
       </div>
 
       <div className="panel right">

--- a/files/testfit/src/basemap.js
+++ b/files/testfit/src/basemap.js
@@ -1,0 +1,156 @@
+// ============================================================
+// basemap.js — slippy-map raster tiles under the plan.
+//
+// The plan lives in a local "ground meters" frame whose origin
+// (0,0) is pinned to a geographic anchor {lat, lon}. Tiles are
+// web-mercator; at parcel scale the equirectangular ↔ mercator
+// mismatch is negligible, so each visible tile is placed by
+// converting its geographic corners into local meters.
+// ============================================================
+
+const R = 111320; // meters per degree of latitude (mean)
+
+// ---- Geographic <-> local meters (anchor-relative, equirectangular) ----
+export function localToLatLon(p, geo) {
+  const lat = geo.lat - p.y / R;
+  const lon = geo.lon + p.x / (R * Math.cos((geo.lat * Math.PI) / 180));
+  return { lat, lon };
+}
+export function latLonToLocal(ll, geo) {
+  const x = (ll.lon - geo.lon) * R * Math.cos((geo.lat * Math.PI) / 180);
+  const y = (geo.lat - ll.lat) * R;
+  return { x, y };
+}
+
+// ---- Geographic <-> slippy tile coordinates ----
+function latLonToTileF(lat, lon, z) {
+  const n = 2 ** z;
+  const latRad = (lat * Math.PI) / 180;
+  const x = ((lon + 180) / 360) * n;
+  const y = ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * n;
+  return { x, y };
+}
+function tileToLatLon(x, y, z) {
+  const n = 2 ** z;
+  const lon = (x / n) * 360 - 180;
+  const latRad = Math.atan(Math.sinh(Math.PI * (1 - (2 * y) / n)));
+  return { lat: (latRad * 180) / Math.PI, lon };
+}
+
+// ---- Basemap styles ----
+// Each style is an ordered list of tile layers (base first, labels on top).
+export const BASEMAPS = {
+  none: { label: 'Geen', layers: [], attribution: '' },
+  osm: {
+    label: 'OpenStreetMap',
+    layers: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+    attribution: '© OpenStreetMap contributors',
+  },
+  satellite: {
+    label: 'Satelliet',
+    layers: ['https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+    attribution: 'Bron: Esri, Maxar, Earthstar Geographics',
+  },
+  hybrid: {
+    label: 'Hybride',
+    layers: [
+      'https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+      'https://services.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}',
+    ],
+    attribution: 'Bron: Esri, Maxar, Earthstar Geographics',
+  },
+};
+
+// ---- Tile cache & async loader ----
+const cache = new Map(); // key -> HTMLImageElement (may be loading/failed)
+const MAX_TILES = 500;
+let redraw = () => {};
+export function setRedraw(fn) { redraw = fn; }
+
+function tileURL(tpl, z, x, y) {
+  return tpl.replace('{z}', z).replace('{x}', x).replace('{y}', y);
+}
+
+function getTile(tpl, z, x, y) {
+  const key = tpl + '|' + z + '|' + x + '|' + y;
+  let img = cache.get(key);
+  if (img) return img;
+  img = new Image();
+  img.crossOrigin = 'anonymous'; // keep the canvas exportable (servers send CORS)
+  img._ok = false;
+  img.onload = () => { img._ok = true; redraw(); };
+  img.onerror = () => { img._failed = true; };
+  img.src = tileURL(tpl, z, x, y);
+  cache.set(key, img);
+  if (cache.size > MAX_TILES) {
+    const oldest = cache.keys().next().value;
+    cache.delete(oldest);
+  }
+  return img;
+}
+
+/**
+ * Pick the web-mercator zoom whose native ground resolution best
+ * matches the current on-screen scale (CSS px per ground meter).
+ */
+export function pickZoom(view, geo) {
+  const latRad = (geo.lat * Math.PI) / 180;
+  const targetRes = 1 / view.scale; // meters per CSS pixel
+  let z = Math.round(Math.log2((156543.033928 * Math.cos(latRad)) / targetRes));
+  return Math.max(2, Math.min(19, z));
+}
+
+/**
+ * Draw the active basemap under the plan. `w2s` maps local meters to
+ * screen (CSS px); `view`/`size` define the visible rectangle.
+ */
+export function drawBasemap(ctx, { style, geo, view, size, w2s }) {
+  const meta = BASEMAPS[style];
+  if (!meta || meta.layers.length === 0) return;
+  const z = pickZoom(view, geo);
+  const n = 2 ** z;
+
+  // Visible local-meter rectangle → geographic → tile index range.
+  const s2w = (p) => ({ x: (p.x - view.ox) / view.scale, y: (p.y - view.oy) / view.scale });
+  const corners = [
+    { x: 0, y: 0 }, { x: size.w, y: 0 }, { x: 0, y: size.h }, { x: size.w, y: size.h },
+  ].map((c) => latLonToTileF(...llArgs(localToLatLon(s2w(c), geo)), z));
+  const minX = Math.floor(Math.min(...corners.map((t) => t.x)));
+  const maxX = Math.floor(Math.max(...corners.map((t) => t.x)));
+  const minY = Math.floor(Math.min(...corners.map((t) => t.y)));
+  const maxY = Math.floor(Math.max(...corners.map((t) => t.y)));
+
+  // Bail out on absurd ranges (guards against degenerate views).
+  if ((maxX - minX) * (maxY - minY) > 600) return;
+
+  ctx.imageSmoothingEnabled = true;
+  for (const tpl of meta.layers) {
+    for (let ty = minY; ty <= maxY; ty++) {
+      if (ty < 0 || ty >= n) continue;
+      for (let tx = minX; tx <= maxX; tx++) {
+        const wx = ((tx % n) + n) % n;
+        const img = getTile(tpl, z, wx, ty);
+        if (!img._ok) continue;
+        const nw = w2s(latLonToLocal(tileToLatLon(tx, ty, z), geo));
+        const se = w2s(latLonToLocal(tileToLatLon(tx + 1, ty + 1, z), geo));
+        // +1px overdraw hides hairline seams between adjacent tiles.
+        ctx.drawImage(img, nw.x, nw.y, se.x - nw.x + 1, se.y - nw.y + 1);
+      }
+    }
+  }
+}
+
+function llArgs(ll) { return [ll.lat, ll.lon]; }
+
+/**
+ * Geocode a free-text query via OSM Nominatim.
+ * Returns { lat, lon, label } or null.
+ */
+export async function geocode(query) {
+  const url = 'https://nominatim.openstreetmap.org/search?format=jsonv2&limit=1&q=' + encodeURIComponent(query);
+  const res = await fetch(url, { headers: { 'Accept-Language': 'nl' } });
+  if (!res.ok) throw new Error('geocode failed');
+  const data = await res.json();
+  if (!data.length) return null;
+  return { lat: parseFloat(data[0].lat), lon: parseFloat(data[0].lon), label: data[0].display_name };
+}

--- a/files/testfit/styles.css
+++ b/files/testfit/styles.css
@@ -151,6 +151,34 @@ canvas { display: block; touch-action: none; }
 }
 .hud b { color: var(--text); font-weight: 600; }
 
+.attrib {
+  position: absolute;
+  right: 6px;
+  bottom: 6px;
+  padding: 2px 7px;
+  background: rgba(15, 18, 22, 0.7);
+  border-radius: 4px;
+  font-size: 10px;
+  color: var(--muted);
+  pointer-events: none;
+  max-width: 60%;
+  text-align: right;
+}
+
+.geo-form { display: flex; gap: 6px; }
+.geo-form input {
+  flex: 1;
+  min-width: 0;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 6px 8px;
+  font-size: 12.5px;
+}
+.geo-msg { margin-top: 8px; font-size: 11.5px; color: var(--muted); line-height: 1.4; }
+.geo-coord { margin-top: 8px; font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; }
+
 .hint {
   position: absolute;
   top: 12px;


### PR DESCRIPTION
Vervolg op #14 (die is gemerged). Deze branch is opnieuw vanaf `main` gestart.

## 1. Laadprobleem opgelost

De melding *"er is herhaaldelijk iets misgegaan bij het laden"* (Safari/iOS) kwam vrijwel zeker door `<script type="importmap">`, dat pas werkt vanaf **iOS Safari 16.4+**. Zonder ondersteuning startte de app niet.

- **Import-map verwijderd** — React/ReactDOM/htm worden nu als klassieke UMD-scripts geladen en via **relatieve paden** geïmporteerd. ES-modules werken al sinds iOS 10.3, dus de app boot nu veel breder.
- **devicePixelRatio afgetopt op 2** — voorkomt een te grote canvas-backing-store die mobiel Safari op hi-DPI-schermen kan laten crashen.
- **Boot-foutoverlay** in `index.html` — bij een laadfout verschijnt nu een leesbare melding met "Opnieuw proberen" i.p.v. een blanco/crash-scherm.

## 2. Kaarten om op te plannen (`src/basemap.js`)

- Plan bovenop **OpenStreetMap**, **Satelliet** (Esri World Imagery) of **Hybride** (satelliet + labels), kiesbaar in het linkerpaneel.
- **Locatie zoeken** (OSM Nominatim): de site wordt her-verankerd op de gevonden coördinaten en de luchtbeelden lijnen uit met de site-geometrie.
- Slippy-map tegel-engine: lokaal grond-meterframe verankerd aan een geografisch punt, per-tegel plaatsing door tegelhoeken naar lokale meters te converteren, zoomniveau afgeleid van de schermschaal, tegelcache met CORS zodat PNG-export blijft werken.
- Attributie-overlay + live centrumcoördinaten in de HUD.

## Getest

- Coördinaat/zoom-wiskunde in Node (exacte round-trips).
- Volledige app in headless Chromium: mount zonder uncaught errors, basemap wisselen (OSM/satelliet/hybride), geocode-fout wordt netjes afgehandeld, dropdown-selectie werkt. De externe tegels/Nominatim zijn in de testsandbox geblokkeerd (proxy) maar werken in een gewone browser.

## Opmerkingen

Kaarttegels en geocoding zijn de enige externe verzoeken; de rest werkt offline door. Attributie wordt getoond zoals vereist door OSM/Esri.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_