### PR TITLE
ParkPlanner: fix iOS Safari-crash (oneindige teken-loop)

### DIFF
--- a/files/testfit/index.html
+++ b/files/testfit/index.html
@@ -38,6 +38,14 @@
           '</div>';
       }
       function fail(headline) { if (shown) return; shown = true; render(headline); }
+      // Breadcrumbs survive a hard WebContent crash: on the next load we can
+      // report how far the previous attempt got.
+      window.__pp_mark = function (s) { try { localStorage.setItem('pp_step', s); } catch (e) {} };
+      try {
+        var prev = localStorage.getItem('pp_step');
+        if (prev && prev !== 'ok') errors.push('Vorige poging stopte bij stap: ' + prev);
+      } catch (e) {}
+      window.__pp_mark('0-html-geladen');
       window.addEventListener('error', function (e) {
         if (e && e.target && (e.target.tagName === 'SCRIPT' || e.target.tagName === 'LINK')) {
           errors.push('Kon niet laden: ' + (e.target.src || e.target.href));

--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -12,6 +12,8 @@ import * as basemap from './basemap.js';
 import { BASEMAPS, geocode } from './basemap.js';
 
 const html = htm.bind(React.createElement);
+const mark = (s) => { try { window.__pp_mark && window.__pp_mark(s); } catch (e) {} };
+mark('1-module-uitgevoerd');
 
 // ---------- Presets & defaults ----------
 const PRESETS = {
@@ -80,7 +82,13 @@ function makeTransform(view) {
 
 function fitView(site, width, height, pad = 60) {
   const bb = boundingBox(site);
-  const scale = Math.min((width - pad * 2) / bb.w, (height - pad * 2) / bb.h);
+  // Can't fit before layout has a real size — signal "not yet".
+  if (!(width > 0) || !(height > 0) || !(bb.w > 0) || !(bb.h > 0)) return null;
+  const usableW = Math.max(20, width - pad * 2);
+  const usableH = Math.max(20, height - pad * 2);
+  // Always a finite, positive scale — a negative/NaN scale would make the
+  // world-space draw loops run forever and crash the tab.
+  const scale = Math.max(0.2, Math.min(200, Math.min(usableW / bb.w, usableH / bb.h)));
   const ox = (width - bb.w * scale) / 2 - bb.minX * scale;
   const oy = (height - bb.h * scale) / 2 - bb.minY * scale;
   return { scale, ox, oy };
@@ -205,6 +213,8 @@ function drawGrid(ctx, view, size) {
   const steps = [1, 2, 5, 10, 20, 50, 100, 200];
   const stepM = steps.find((s) => s * view.scale >= 45) || 200;
   const px = stepM * view.scale;
+  // Hard guard: a non-positive/non-finite pixel step would loop forever.
+  if (!(px > 0) || !isFinite(px)) return;
   const startX = ((view.ox % px) + px) % px;
   const startY = ((view.oy % px) + px) % px;
   ctx.strokeStyle = 'rgba(255,255,255,0.045)';
@@ -239,12 +249,14 @@ function App() {
   const solveTimer = useRef(null);
   const fittedRef = useRef(false);
   const renderRef = useRef(() => {}); // always points at the latest renderNow
+  const drewRef = useRef(false); // set once the first frame draws (breadcrumb)
 
   // Once mounted, cancel the index.html boot-failure fallback and let
   // the tile loader trigger redraws as tiles arrive.
   useEffect(() => {
     if (window.__pp_boot) { clearTimeout(window.__pp_boot); window.__pp_boot = null; }
     basemap.setRedraw(() => renderRef.current());
+    mark('3-gemount');
   }, []);
 
   // Resize handling + initial fit. DPR capped at 2 to avoid huge canvas
@@ -256,13 +268,13 @@ function App() {
       sizeRef.current = { w: r.width, h: r.height };
       const canvas = canvasRef.current;
       const dpr = Math.min(2, window.devicePixelRatio || 1);
-      canvas.width = Math.round(r.width * dpr);
-      canvas.height = Math.round(r.height * dpr);
+      canvas.width = Math.max(1, Math.round(r.width * dpr));
+      canvas.height = Math.max(1, Math.round(r.height * dpr));
       canvas.style.width = r.width + 'px';
       canvas.style.height = r.height + 'px';
-      if (!fittedRef.current && r.width > 0) {
-        setView(fitView(doc.site, r.width, r.height));
-        fittedRef.current = true;
+      if (!fittedRef.current && r.width > 0 && r.height > 0) {
+        const fv = fitView(doc.site, r.width, r.height);
+        if (fv) { setView(fv); fittedRef.current = true; }
       }
       renderRef.current();
     });
@@ -286,6 +298,10 @@ function App() {
   const renderNow = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
+    const sz = sizeRef.current;
+    // Never draw with a zero canvas or a non-finite scale — those are the
+    // conditions that turn world-space draw loops into infinite loops.
+    if (!(sz.w > 0) || !(sz.h > 0) || !(view.scale > 0) || !isFinite(view.scale)) return;
     const ctx = canvas.getContext('2d');
     draw(ctx, {
       view, doc, result, layers,
@@ -293,6 +309,7 @@ function App() {
       drawing, hover, selection, size: sizeRef.current,
       showHandles: tool === 'select', basemapStyle,
     });
+    if (!drewRef.current) { drewRef.current = true; mark('ok'); }
   }, [view, doc, result, layers, drawing, hover, selection, tool, basemapStyle]);
 
   renderRef.current = renderNow;
@@ -469,7 +486,10 @@ function App() {
   const cycleAxis = () =>
     dispatch({ type: 'COMMIT', updater: (d) => ({ ...d, orientationIndex: (d.orientationIndex + 1) % Math.max(1, result.orientationCount || 1) }) });
   const resetAxis = () => dispatch({ type: 'COMMIT', updater: (d) => ({ ...d, orientationIndex: 0 }) });
-  const fitToSite = () => setView(fitView(doc.site, sizeRef.current.w, sizeRef.current.h));
+  const fitToSite = () => {
+    const fv = fitView(doc.site, sizeRef.current.w, sizeRef.current.h);
+    if (fv) setView(fv);
+  };
 
   const saveJSON = () => {
     const blob = new Blob([JSON.stringify(doc, null, 2)], { type: 'application/json' });
@@ -704,6 +724,7 @@ try {
   if (!window.React || !window.ReactDOM || !window.htm) {
     throw new Error('Kernbibliotheken ontbreken (React/ReactDOM/htm niet geladen).');
   }
+  mark('2-mount-start');
   createRoot(document.getElementById('root')).render(html`<${App} />`);
 } catch (err) {
   window.dispatchEvent(new ErrorEvent('error', { message: 'Mount-fout: ' + (err && err.message), error: err }));


### PR DESCRIPTION
## De echte oorzaak gevonden

De melding *"er heeft zich herhaaldelijk een probleem voorgedaan"* is een **crash van Safari's webproces** bij het laden — alleen op iOS.

Oorzaak: als de eerste layout een **hoogte van 0** rapporteert (komt op mobiel Safari voor, o.a. door de dynamische adresbalk), berekende `fitView()` een **negatieve schaal**. Daardoor liep `drawGrid()`'s lus `for (x = start; x < breedte; x += px)` met een **negatieve stap** → een **oneindige lus** die de CPU vastzette tot iOS het tabblad afsloot. Desktop Chromium had bij de eerste render altijd een echte grootte, dus daar trad het nooit op — en de crash neemt ook mijn eigen fout-overlay mee, waardoor je alleen Safari's scherm zag.

Import-maps en devicePixelRatio waren dus **niet** de oorzaak (jij zit op iOS 27); die eerdere wijzigingen blijven wel als nette verbeteringen staan.

## Fix (defense in depth)

- `fitView()` geeft `null` terug tenzij breedte/hoogte/bbox allemaal positief zijn, en klemt de schaal tot een eindig, positief bereik; aanroepers slaan over bij `null`.
- De resize-handler fit alleen als beide dimensies > 0 en zet de canvas-backing-store op minstens 1px.
- `renderNow()` tekent niet bij een canvas van 0 of een niet-eindige schaal.
- `drawGrid()` stopt vroegtijdig tenzij de pixelstap eindig en positief is.

## Diagnose-vangnet

localStorage-broodkruimels (`0-html → 1-module → 2-mount → 3-gemount → ok`) overleven een harde procescrash, zodat een volgende load toont hoever de vorige poging kwam; de boot-overlay laat dat zien.

## Getest

Headless Chromium: mount, bereikt de `ok`-broodkruimel, en overleeft een resize naar **320×1 px** en terug — precies de crash-conditie — zonder hang of errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_