### PR TITLE
ParkPlanner: mobiele theme-color / web-app meta (+ Pages-herbouw)

### DIFF
--- a/files/testfit/index.html
+++ b/files/testfit/index.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="theme-color" content="#0f1216" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <title>ParkPlanner — TestFit-kloon</title>
   <meta name="description" content="Automatische parkeerplanner: teken een site op OSM- of satellietkaarten, genereer live parkeervakken, rijstroken en metrics. Een open-source TestFit-kloon in React." />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🅿️</text></svg>" />


### PR DESCRIPTION
Kleine mobiele afwerking + hertrigger van de GitHub Pages-deploy (die de vorige merge oversloeg, waardoor de crash-fix uit #17 nog niet live stond).

- `theme-color` (donker) voor de browser-chrome op mobiel.
- `apple-mobile-web-app-*` meta zodat een "zet op beginscherm"-snelkoppeling schermvullend opent met een passende statusbalk.

Bevat cumulatief ook de crash-fix van #17 (oneindige teken-loop bij hoogte 0).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_