### PR TITLE
ParkPlanner: gras + bomen, en ParkPlanner in de profiel-README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@
 
 ## 🌟 Featured Projects
 
+### 🅿️ ParkPlanner — een TestFit-kloon (parkeerplanner) in React
+A self-contained, in-browser **parking planner** inspired by TestFit's Parking Solver.
+Draw a site, and it auto-generates parking stalls, drive aisles and live metrics.
+
+**▶️ Live demo: [vandenostende.github.io/files/testfit/](https://vandenostende.github.io/files/testfit/)**
+
+- Real-time parametric **parking solver** (setback offset → orientation search → strip-packing) — runs fully client-side, no build step.
+- Plan on **OpenStreetMap / satellite / hybrid** basemaps with address search, or view your plan in **3D** with real buildings (bring your own Mapbox token).
+- Mark stalls (EV, accessible, staff, …), set one-way aisles with arrows, and draw **roads, paths, crosswalks, bike parking, grass and trees**.
+- Undo/redo, JSON save/load, PNG export, and jurisdiction presets (US / EU).
+
+Built with React + `htm` (no bundler), a from-scratch geometry/solver engine, and HTML5 Canvas.
+
 ### Currently Contributing To: EV-Charging/Routing Application
 I'm contributing to an application focused on helping electric vehicle owners find optimal charging stations and plan their routes efficiently. The project leverages modern mapping solutions and real-time routing.
 

--- a/files/testfit/README.md
+++ b/files/testfit/README.md
@@ -19,7 +19,12 @@ rijstroken en metrics — geïnspireerd op TestFit's *Parking Solver*.
 - **Rijbanen als eenrichting** — selecteer een rijbaan en zet 'm op eenrichting;
   richtingspijlen verschijnen op de baan (met omkeer-knop).
 - **Infrastructuur tekenen** — wegen (met bochten), wandelpaden, fietspaden,
-  zebrapaden, fietsparking (met capaciteit) en vrije markeringen.
+  zebrapaden, fietsparking (met capaciteit), **gras**, **bomen** en markeringen.
+  Wegen/paden **snappen** aan bestaande hoekpunten en kunnen tot een **gesloten
+  vlak/plein** worden gesloten; **afmetingen** verschijnen live tijdens het tekenen.
+- **Site verplaatsen/verwijderen** — klik de site-rand om de hele site te
+  selecteren, sleep om te verplaatsen, Delete om te verwijderen.
+- **Navigatie** — twee-vinger trackpad pant, pinch/Ctrl+scroll zoomt.
 - **Site tekenen** — polygoon-tool met sleepbare hoekpunten en numerieke oppervlakte.
 - **Gebouwen / uitsluitingszones** — sleep rechthoeken die de solver respecteert.
 - **Automatische parkeergeneratie** — dubbel-belaste modules, live herberekend.

--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -53,6 +53,8 @@ export const ANNOT_TYPES = {
   bikepath:    { label: 'Fietspad',     color: '#b91c1c', width: 2.0, mode: 'line', curved: true },
   crosswalk:   { label: 'Zebrapad',     color: '#e5e7eb', width: 3.5, mode: 'cross' },
   bikeparking: { label: 'Fietsparking', color: '#0e7490', width: 0,   mode: 'area', under: true },
+  grass:       { label: 'Gras',         color: '#3f9b46', width: 0,   mode: 'area', under: true },
+  tree:        { label: 'Boom',         color: '#2f9e44', width: 5,   mode: 'point' },
   marking:     { label: 'Markering',    color: '#eab308', width: 0.3, mode: 'line', curved: false },
 };
 
@@ -346,6 +348,49 @@ function drawDims(ctx, pts, w2s) {
   ctx.restore();
 }
 
+// Tree sprites: empty by default (procedural trees are drawn). Once the
+// user supplies tree images, register them here and they're used instead.
+// e.g. window.ParkPlanner.setTreeImages(['data:image/png;base64,…', …])
+const TREE_SPRITES = [];
+if (typeof window !== 'undefined') {
+  window.ParkPlanner = window.ParkPlanner || {};
+  window.ParkPlanner.setTreeImages = (urls) => {
+    TREE_SPRITES.length = 0;
+    (urls || []).forEach((u) => { const im = new Image(); im.src = u; TREE_SPRITES.push(im); });
+  };
+}
+
+function drawTree(ctx, s, rpx, index, selected) {
+  const sprite = TREE_SPRITES.length ? TREE_SPRITES[index % TREE_SPRITES.length] : null;
+  // soft ground shadow
+  ctx.beginPath();
+  ctx.ellipse(s.x, s.y + rpx * 0.25, rpx * 0.95, rpx * 0.5, 0, 0, Math.PI * 2);
+  ctx.fillStyle = 'rgba(0,0,0,0.22)';
+  ctx.fill();
+  if (sprite && sprite.complete && sprite.naturalWidth) {
+    const d = rpx * 2;
+    ctx.drawImage(sprite, s.x - rpx, s.y - d + rpx * 0.6, d, d);
+  } else {
+    const g = ctx.createRadialGradient(s.x - rpx * 0.3, s.y - rpx * 0.3, rpx * 0.2, s.x, s.y, rpx);
+    g.addColorStop(0, '#5fd97f');
+    g.addColorStop(1, '#166534');
+    ctx.beginPath();
+    ctx.arc(s.x, s.y, rpx, 0, Math.PI * 2);
+    ctx.fillStyle = g;
+    ctx.fill();
+    ctx.strokeStyle = 'rgba(0,0,0,0.25)';
+    ctx.lineWidth = 1;
+    ctx.stroke();
+  }
+  if (selected) {
+    ctx.beginPath();
+    ctx.arc(s.x, s.y, rpx + 3, 0, Math.PI * 2);
+    ctx.strokeStyle = '#ffffff';
+    ctx.lineWidth = 2;
+    ctx.stroke();
+  }
+}
+
 // ---- Annotation (infrastructure) rendering ----
 function buildAnnotPath(ctx, pts, curved) {
   ctx.beginPath();
@@ -365,9 +410,16 @@ function buildAnnotPath(ctx, pts, curved) {
   }
 }
 
-function drawAnnotation(ctx, ann, w2s, scale, selected) {
+function drawAnnotation(ctx, ann, w2s, scale, selected, index) {
   const t = ANNOT_TYPES[ann.kind];
-  if (!t || !ann.points || ann.points.length < 2) return;
+  if (!t || !ann.points || ann.points.length < 1) return;
+
+  if (t.mode === 'point') {
+    const rpx = Math.max(3, ((ann.width || t.width || 5) / 2) * scale);
+    drawTree(ctx, w2s(ann.points[0]), rpx, index || 0, selected);
+    return;
+  }
+  if (ann.points.length < 2) return;
 
   if (t.mode === 'cross') {
     const A = ann.points[0], B = ann.points[1];
@@ -397,11 +449,12 @@ function drawAnnotation(ctx, ann, w2s, scale, selected) {
     ctx.beginPath();
     pts.forEach((p, i) => (i ? ctx.lineTo(p.x, p.y) : ctx.moveTo(p.x, p.y)));
     ctx.closePath();
-    ctx.fillStyle = 'rgba(14,116,144,0.35)';
+    ctx.fillStyle = ann.kind === 'grass' ? hexA(t.color, 0.5) : 'rgba(14,116,144,0.35)';
     ctx.fill();
     ctx.strokeStyle = selected ? '#ffffff' : t.color;
     ctx.lineWidth = selected ? 2.5 : 1.5;
     ctx.stroke();
+    if (ann.kind !== 'bikeparking') return;
     const cap = Math.floor(polygonArea(ann.points) / 1.5); // ~1.5 m² per bike
     const c = w2s(polygonCentroid(ann.points));
     ctx.fillStyle = 'rgba(255,255,255,0.92)';
@@ -452,7 +505,7 @@ function drawAnnotations(ctx, anns, w2s, scale, under, selIdx) {
   for (let i = 0; i < anns.length; i++) {
     const t = ANNOT_TYPES[anns[i].kind];
     if (!t || !!t.under !== under) continue;
-    drawAnnotation(ctx, anns[i], w2s, scale, i === selIdx);
+    drawAnnotation(ctx, anns[i], w2s, scale, i === selIdx, i);
   }
 }
 
@@ -712,7 +765,12 @@ function App() {
     for (let i = anns.length - 1; i >= 0; i--) {
       const ann = anns[i];
       const t = ANNOT_TYPES[ann.kind];
-      if (!t || !ann.points || ann.points.length < 2) continue;
+      if (!t || !ann.points || ann.points.length < 1) continue;
+      if (t.mode === 'point') {
+        if (dist(w2s(ann.points[0]), sp) < Math.max(8, ((ann.width || 5) / 2) * view.scale)) return i;
+        continue;
+      }
+      if (ann.points.length < 2) continue;
       const pts = ann.points.map(w2s);
       const tol = Math.max(6, ((ann.width || 1) * view.scale) / 2 + 4);
       if (t.mode === 'area' || ann.closed) {
@@ -820,6 +878,7 @@ function App() {
     if (tool === 'annot') {
       const t = ANNOT_TYPES[annotKind];
       const snap = snapPoint(sp);
+      if (t.mode === 'point') { addAnnotation({ kind: annotKind, points: [snap], width: annotWidth }); return; }
       if (t.mode === 'area') { dragRef.current = { mode: 'annotArea', start: snap, cur: snap }; return; }
       // line / cross: accumulate points; clicking the first point closes it
       // into a filled area (weg/plein).
@@ -1064,7 +1123,9 @@ function App() {
     site: 'Klik om punten te plaatsen · klik het eerste punt of dubbelklik om te sluiten · Esc annuleert',
     obstacle: 'Sleep een rechthoek voor een gebouw / uitsluitingszone',
     pan: 'Sleep om te verschuiven',
-    annot: ANNOT_TYPES[annotKind] && ANNOT_TYPES[annotKind].mode === 'area'
+    annot: ANNOT_TYPES[annotKind] && ANNOT_TYPES[annotKind].mode === 'point'
+      ? `${ANNOT_TYPES[annotKind].label}: klik om te plaatsen · Esc stopt`
+      : ANNOT_TYPES[annotKind] && ANNOT_TYPES[annotKind].mode === 'area'
       ? `${ANNOT_TYPES[annotKind].label}: sleep een rechthoek`
       : ANNOT_TYPES[annotKind] && ANNOT_TYPES[annotKind].mode === 'cross'
         ? `${ANNOT_TYPES[annotKind].label}: klik begin- en eindpunt van de oversteek`
@@ -1128,8 +1189,8 @@ function App() {
           </div>
           ${tool === 'annot' && ANNOT_TYPES[annotKind].mode !== 'area' && html`
             <div className="field" style=${{ marginTop: '10px', marginBottom: 0 }}>
-              <label>Breedte<span className="val">${annotWidth.toFixed(1)} m</span></label>
-              <input type="range" min="0.2" max="12" step="0.1" value=${annotWidth}
+              <label>${ANNOT_TYPES[annotKind].mode === 'point' ? 'Kroondiameter' : 'Breedte'}<span className="val">${annotWidth.toFixed(1)} m</span></label>
+              <input type="range" min=${ANNOT_TYPES[annotKind].mode === 'point' ? 1 : 0.2} max=${ANNOT_TYPES[annotKind].mode === 'point' ? 15 : 12} step="0.1" value=${annotWidth}
                 onInput=${(e) => setAnnotWidth(parseFloat(e.target.value))} />
               ${ANNOT_TYPES[annotKind].mode === 'line' && html`
                 <label className="toggle" style=${{ marginTop: '8px' }}>

--- a/files/testfit/src/map3d.js
+++ b/files/testfit/src/map3d.js
@@ -45,19 +45,28 @@ function lineFeature(pts, geo, props) {
 }
 
 function planToGeoJSON(plan, geo) {
+  const anns = plan.annotations || [];
   const stalls = { type: 'FeatureCollection', features: (plan.stalls || []).map((s) =>
     polyFeature(s.poly, geo, { color: (STALL_TYPES[s.type] || STALL_TYPES.standard).color })) };
   const aisles = { type: 'FeatureCollection', features: (plan.aisles || []).map((a) => polyFeature(a.poly, geo, {})) };
   const buildings = { type: 'FeatureCollection', features: (plan.obstacles || []).map((o) => polyFeature(o, geo, { height: 12 })) };
   const site = { type: 'FeatureCollection', features: plan.site && plan.site.length >= 3 ? [polyFeature(plan.site, geo, {})] : [] };
-  const lines = { type: 'FeatureCollection', features: (plan.annotations || [])
-    .filter((an) => an.points && an.points.length >= 2 && an.kind !== 'bikeparking')
+  // Filled areas: grass, bike parking, and closed line-annotations (pleinen).
+  const areas = { type: 'FeatureCollection', features: anns
+    .filter((an) => an.points && an.points.length >= 3 && (an.kind === 'grass' || an.kind === 'bikeparking' || an.closed))
+    .map((an) => polyFeature(an.points, geo, { color: annColor(an.kind) })) };
+  const lines = { type: 'FeatureCollection', features: anns
+    .filter((an) => an.points && an.points.length >= 2 && !an.closed && ['road', 'walkway', 'bikepath', 'crosswalk', 'marking'].includes(an.kind))
     .map((an) => lineFeature(an.points, geo, { color: annColor(an.kind), width: an.width || 1 })) };
-  return { stalls, aisles, buildings, site, lines };
+  const trees = { type: 'FeatureCollection', features: anns
+    .filter((an) => an.kind === 'tree' && an.points && an.points[0])
+    .map((an) => { const ll = localToLatLon(an.points[0], geo); return { type: 'Feature', properties: { r: (an.width || 5) / 2 }, geometry: { type: 'Point', coordinates: [ll.lon, ll.lat] } }; }) };
+  return { stalls, aisles, buildings, site, areas, lines, trees };
 }
 
 function annColor(kind) {
-  return ({ road: '#3b424e', walkway: '#9aa4b2', bikepath: '#b91c1c', crosswalk: '#e5e7eb', marking: '#eab308' })[kind] || '#eab308';
+  return ({ road: '#3b424e', walkway: '#9aa4b2', bikepath: '#b91c1c', crosswalk: '#e5e7eb',
+    marking: '#eab308', grass: '#3f9b46', bikeparking: '#0e7490', tree: '#2f9e44' })[kind] || '#eab308';
 }
 
 function addLayers(map, plan, geo) {
@@ -65,7 +74,10 @@ function addLayers(map, plan, geo) {
   const src = (id, data) => { if (!map.getSource(id)) map.addSource(id, { type: 'geojson', data }); };
   src('pp-site', g.site); src('pp-aisles', g.aisles); src('pp-stalls', g.stalls);
   src('pp-buildings', g.buildings); src('pp-lines', g.lines);
+  src('pp-areas', g.areas); src('pp-trees', g.trees);
 
+  if (!map.getLayer('pp-areas-fill')) map.addLayer({ id: 'pp-areas-fill', type: 'fill', source: 'pp-areas',
+    paint: { 'fill-color': ['get', 'color'], 'fill-opacity': 0.55 } });
   if (!map.getLayer('pp-site-line')) map.addLayer({ id: 'pp-site-line', type: 'line', source: 'pp-site',
     paint: { 'line-color': '#f8b500', 'line-width': 2 } });
   if (!map.getLayer('pp-aisles-fill')) map.addLayer({ id: 'pp-aisles-fill', type: 'fill', source: 'pp-aisles',
@@ -76,6 +88,9 @@ function addLayers(map, plan, geo) {
     paint: { 'fill-color': ['get', 'color'], 'fill-opacity': 0.9, 'fill-outline-color': 'rgba(0,0,0,0.4)' } });
   if (!map.getLayer('pp-buildings-3d')) map.addLayer({ id: 'pp-buildings-3d', type: 'fill-extrusion', source: 'pp-buildings',
     paint: { 'fill-extrusion-color': '#8a97a8', 'fill-extrusion-height': ['get', 'height'], 'fill-extrusion-opacity': 0.9 } });
+  // Trees as green cylinders (canopy radius drives base width).
+  if (!map.getLayer('pp-trees-3d')) map.addLayer({ id: 'pp-trees-3d', type: 'circle', source: 'pp-trees',
+    paint: { 'circle-color': '#2f9e44', 'circle-radius': ['interpolate', ['linear'], ['zoom'], 15, 3, 20, ['*', ['get', 'r'], 6]], 'circle-stroke-color': '#14532d', 'circle-stroke-width': 1, 'circle-opacity': 0.9 } });
 }
 
 function setData(map, plan, geo) {
@@ -84,6 +99,7 @@ function setData(map, plan, geo) {
   const set = (id, data) => { const s = map.getSource(id); if (s) s.setData(data); };
   set('pp-site', g.site); set('pp-aisles', g.aisles); set('pp-stalls', g.stalls);
   set('pp-buildings', g.buildings); set('pp-lines', g.lines);
+  set('pp-areas', g.areas); set('pp-trees', g.trees);
 }
 
 /**


### PR DESCRIPTION
Landschap + README.

- **Gras**: teken een rechthoekig groen vlak (onder het parkeren).
- **Boom**: klik om bomen te plaatsen, met instelbare kroondiameter; procedurele boomkronen met schaduw. Bevat een haak (`window.ParkPlanner.setTreeImages`) om later echte boom-afbeeldingen in te laden.
- Beide selecteerbaar/verwijderbaar; gras-vlakken en boom-cirkels renderen ook in de Mapbox 3D-weergave.
- **Root `README.md`**: ParkPlanner toegevoegd onder "Featured Projects" met live-link en feature-overzicht; app-README bijgewerkt.

## Getest
Headless Chromium: gras tekenen, meerdere bomen plaatsen + selecteren — geen console-errors; screenshot bevestigt gras-vlak en boomkronen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_