### PR TITLE
ParkPlanner: export naar GeoJSON, DXF en CSV

### DIFF
--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -11,6 +11,7 @@ import {
 } from './geometry.js';
 import * as basemap from './basemap.js';
 import { BASEMAPS, geocode } from './basemap.js';
+import { toGeoJSON, toDXF, toCSV } from './exporters.js';
 
 const html = htm.bind(React.createElement);
 const mark = (s) => { try { window.__pp_mark && window.__pp_mark(s); } catch (e) {} };
@@ -551,6 +552,7 @@ function App() {
   const [mbToken, setMbToken] = useState(() => { try { return localStorage.getItem('pp_mapbox_token') || ''; } catch (e) { return ''; } });
   const [mbTokenInput, setMbTokenInput] = useState('');
   const [map3dError, setMap3dError] = useState('');
+  const [exportOpen, setExportOpen] = useState(false);
 
   const wrapRef = useRef(null);
   const canvasRef = useRef(null);
@@ -1076,6 +1078,12 @@ function App() {
   const exportPNG = () => {
     canvasRef.current.toBlob((blob) => downloadBlob(blob, 'parkplanner.png'));
   };
+  const exportGeoJSON = () =>
+    downloadBlob(new Blob([JSON.stringify(toGeoJSON(buildPlan(), doc.geo), null, 2)], { type: 'application/geo+json' }), 'parkplanner.geojson');
+  const exportDXF = () =>
+    downloadBlob(new Blob([toDXF(buildPlan())], { type: 'application/dxf' }), 'parkplanner.dxf');
+  const exportCSV = () =>
+    downloadBlob(new Blob([toCSV(buildPlan(), metrics)], { type: 'text/csv;charset=utf-8' }), 'parkplanner.csv');
   const newRect = () => {
     dispatch({ type: 'RESET', doc: { ...initialDoc, site: rectPoly(0, 0, 80, 50), obstacles: [] } });
     setTimeout(fitToSite, 0);
@@ -1160,7 +1168,16 @@ function App() {
         <button className="btn ghost" onClick=${fitToSite}>⤢ Fit</button>
         <button className="btn ghost" onClick=${saveJSON}>Opslaan</button>
         <label className="btn ghost">Laden<input type="file" accept="application/json" onChange=${loadJSON} style=${{ display: 'none' }} /></label>
-        <button className="btn ghost" onClick=${exportPNG}>PNG</button>
+        <div className="dropdown">
+          <button className="btn ghost" onClick=${() => setExportOpen((o) => !o)}>Export ▾</button>
+          ${exportOpen && html`
+            <div className="menu" onMouseLeave=${() => setExportOpen(false)}>
+              <button onClick=${() => { exportPNG(); setExportOpen(false); }}>PNG-afbeelding</button>
+              <button onClick=${() => { exportGeoJSON(); setExportOpen(false); }}>GeoJSON</button>
+              <button onClick=${() => { exportDXF(); setExportOpen(false); }}>DXF (CAD)</button>
+              <button onClick=${() => { exportCSV(); setExportOpen(false); }}>CSV (takeoff)</button>
+            </div>`}
+        </div>
       </div>
 
       <div className="panel left">

--- a/files/testfit/src/exporters.js
+++ b/files/testfit/src/exporters.js
@@ -1,0 +1,82 @@
+// ============================================================
+// exporters.js — GeoJSON / DXF / CSV export of the plan.
+//
+// The plan lives in a local metre frame anchored to doc.geo; GeoJSON is
+// produced in real lng/lat via the same anchor used by the basemap tiles
+// and the 3D view. DXF/CSV use the raw local metres.
+// ============================================================
+import { localToLatLon } from './basemap.js';
+
+const AREA_KINDS = ['bikeparking', 'grass']; // annotation kinds that are filled areas
+
+// ---------- GeoJSON ----------
+export function toGeoJSON(plan, geo) {
+  const ll = (p) => { const g = localToLatLon(p, geo); return [g.lon, g.lat]; };
+  const ring = (poly) => {
+    const r = poly.map(ll);
+    if (r.length && (r[0][0] !== r[r.length - 1][0] || r[0][1] !== r[r.length - 1][1])) r.push(r[0]);
+    return r;
+  };
+  const poly = (pts, props) => ({ type: 'Feature', properties: props, geometry: { type: 'Polygon', coordinates: [ring(pts)] } });
+  const line = (pts, props) => ({ type: 'Feature', properties: props, geometry: { type: 'LineString', coordinates: pts.map(ll) } });
+  const point = (pt, props) => ({ type: 'Feature', properties: props, geometry: { type: 'Point', coordinates: ll(pt) } });
+
+  const feats = [];
+  if (plan.site && plan.site.length >= 3) feats.push(poly(plan.site, { kind: 'site' }));
+  (plan.obstacles || []).forEach((o) => feats.push(poly(o, { kind: 'building' })));
+  (plan.aisles || []).forEach((a) => feats.push(poly(a.poly, { kind: 'aisle', oneway: !!a.oneway })));
+  (plan.stalls || []).forEach((s) => feats.push(poly(s.poly, { kind: 'stall', type: s.type })));
+  (plan.annotations || []).forEach((an) => {
+    if (!an.points || !an.points.length) return;
+    if (an.kind === 'tree') feats.push(point(an.points[0], { kind: 'tree', diameter: an.width || 5 }));
+    else if (an.points.length >= 3 && (AREA_KINDS.includes(an.kind) || an.closed)) feats.push(poly(an.points, { kind: an.kind }));
+    else if (an.points.length >= 2) feats.push(line(an.points, { kind: an.kind, width: an.width || 1 }));
+  });
+  return { type: 'FeatureCollection', features: feats };
+}
+
+// ---------- DXF (ASCII, minimal R12-style ENTITIES) ----------
+export function toDXF(plan) {
+  const out = [];
+  const g = (code, val) => { out.push(String(code)); out.push(String(val)); };
+  // CAD is Y-up; the app frame is Y-down, so negate Y.
+  const addPoly = (pts, layer, closed) => {
+    g(0, 'LWPOLYLINE'); g(8, layer); g(90, pts.length); g(70, closed ? 1 : 0);
+    pts.forEach((p) => { g(10, p.x.toFixed(3)); g(20, (-p.y).toFixed(3)); });
+  };
+  const addCircle = (c, r, layer) => { g(0, 'CIRCLE'); g(8, layer); g(10, c.x.toFixed(3)); g(20, (-c.y).toFixed(3)); g(40, r.toFixed(3)); };
+
+  g(0, 'SECTION'); g(2, 'ENTITIES');
+  if (plan.site && plan.site.length >= 3) addPoly(plan.site, 'SITE', true);
+  (plan.obstacles || []).forEach((o) => addPoly(o, 'BUILDINGS', true));
+  (plan.aisles || []).forEach((a) => addPoly(a.poly, 'AISLES', true));
+  (plan.stalls || []).forEach((s) => addPoly(s.poly, 'STALLS_' + (s.type || 'standard').toUpperCase(), true));
+  (plan.annotations || []).forEach((an) => {
+    if (!an.points || !an.points.length) return;
+    const layer = String(an.kind).toUpperCase();
+    if (an.kind === 'tree') addCircle(an.points[0], (an.width || 5) / 2, 'TREES');
+    else if (an.points.length >= 3 && (AREA_KINDS.includes(an.kind) || an.closed)) addPoly(an.points, layer, true);
+    else if (an.points.length >= 2) addPoly(an.points, layer, false);
+  });
+  g(0, 'ENDSEC'); g(0, 'EOF');
+  return out.join('\n');
+}
+
+// ---------- CSV (quantity takeoff) ----------
+export function toCSV(plan, metrics) {
+  const rows = [['Categorie', 'Waarde']];
+  rows.push(['Totaal vakken', metrics.total]);
+  Object.entries(metrics.counts || {}).forEach(([k, v]) => rows.push(['Vakken — ' + k, v]));
+  rows.push(['Site oppervlak (m2)', Math.round(metrics.siteArea)]);
+  rows.push(['Bebouwd (m2)', Math.round(metrics.buildingArea)]);
+  rows.push(['Beschikbaar/buildable (m2)', Math.round(metrics.buildableArea)]);
+  rows.push(['m2 per vak', metrics.total ? metrics.areaPerStall.toFixed(1) : '0']);
+  rows.push(['Bebouwingsgraad (%)', (metrics.coverage * 100).toFixed(0)]);
+  if (metrics.imperviousPct != null) rows.push(['Verhard/impervious (%)', (metrics.imperviousPct * 100).toFixed(0)]);
+  rows.push(['Minder-valide vereist', metrics.adaRequired]);
+  rows.push(['Minder-valide geleverd', metrics.adaProvided]);
+  rows.push(['Eenrichtings-rijbanen', (metrics.onewayAisles || 0) + '/' + (metrics.aisleCount || 0)]);
+  if (metrics.requiredStalls != null) rows.push(['Vereiste plaatsen (zoning)', metrics.requiredStalls]);
+  const esc = (c) => '"' + String(c).replace(/"/g, '""') + '"';
+  return rows.map((r) => r.map(esc).join(',')).join('\n');
+}

--- a/files/testfit/styles.css
+++ b/files/testfit/styles.css
@@ -75,6 +75,33 @@ body {
 .brand small { color: var(--muted); font-weight: 500; font-size: 11px; }
 
 .tb-sep { width: 1px; height: 24px; background: var(--border); margin: 0 4px; }
+
+.dropdown { position: relative; }
+.dropdown .menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  z-index: 40;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  padding: 4px;
+  min-width: 160px;
+  display: flex;
+  flex-direction: column;
+}
+.dropdown .menu button {
+  text-align: left;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  padding: 8px 10px;
+  border-radius: 5px;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+.dropdown .menu button:hover { background: var(--panel-2); }
 .tb-spacer { flex: 1; }
 
 .btn {


### PR DESCRIPTION
Stage F van de roadmap: exports.

Nieuwe **Export ▾**-knop in de werkbalk (vervangt de losse PNG-knop) met **PNG / GeoJSON / DXF / CSV**.

- **GeoJSON** (`src/exporters.js`): `FeatureCollection` met site, gebouwen, rijstroken, vakken (met `type`) en annotaties (polygonen/lijnen/punten) in echte lng/lat via hetzelfde geo-anker als de kaart/3D.
- **DXF** (CAD): minimale ASCII-DXF met `LWPOLYLINE` per element op eigen layers (SITE, STALLS_*, AISLES, BUILDINGS, ROAD, GRASS, …), bomen als `CIRCLE`, Y omgekeerd voor de CAD-conventie. Geen dependency.
- **CSV** (takeoff): aantallen per vaktype, oppervlaktes, bebouwingsgraad, minder-valide.

## Getest
Node-unittest (GeoJSON parse-baar met 9 features/7 kinds; DXF met SECTION/LWPOLYLINE/CIRCLE/EOF; CSV-koppen) en headless Chromium (alle drie exporteren een download). Geen console-errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_