### PR TITLE
ParkPlanner: parkeerratio-calculator, verhard %, toegangspunten

### DIFF
--- a/files/testfit/README.md
+++ b/files/testfit/README.md
@@ -89,11 +89,20 @@ los te testen met Node.
 
 Zoom met het scrollwiel; pan met de Pan-tool, middelste muisknop of `Shift`+slepen.
 
-## Roadmap (nice-to-have)
+## Recente uitbreidingen
 
-Web-worker voor de solve bij grote sites, single-loaded rijen & dead-end
-turnarounds, manual override met pin/lock op vakken en rijstroken, licht-gekantelde
-2.5D-weergave, en DXF/GeoJSON-export.
+- **Export** naar GeoJSON, DXF (CAD) en CSV (takeoff), naast PNG/JSON.
+- **Web-worker solve** (met inline-fallback) zodat grote sites de UI niet bevriezen.
+- **Single-loaded rijen & dead-end turnarounds** als solver-opties.
+- **Pin/lock** op vakken en rijstroken (blijven bij "wis markering").
+- **2.5D** gekantelde alleen-lezen weergave (naast de Mapbox 3D).
+- **Programma & parkeerratio** (GLA → vereiste plaatsen), **impervious/verhard %**,
+  en **toegangspunten** op de site-rand.
+
+## Roadmap (grotere epics)
+
+Meerlaags structured/garage-parking (tray counts), site-import (GeoJSON/KML/DXF),
+generatieve varianten, en PDF/Revit/glTF-export.
 
 ---
 

--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -30,6 +30,7 @@ const DEFAULT_PARAMS = {
   angle: 90, setback: 6, padding: 0.6, maxRun: 12,
   compactRatio: 0, evRatio: 0.05, ada: true,
   singleLoaded: false, deadEndTurnaround: false, turnaround: 7,
+  buildingGLA: 0, parkingRatio: 0, // GLA (m²) + stalls per 100 m² (zoning)
 };
 
 // Default demo site: an L-shaped parcel (rectangle with a building in the corner).
@@ -57,6 +58,7 @@ export const ANNOT_TYPES = {
   bikeparking: { label: 'Fietsparking', color: '#0e7490', width: 0,   mode: 'area', under: true },
   grass:       { label: 'Gras',         color: '#3f9b46', width: 0,   mode: 'area', under: true },
   tree:        { label: 'Boom',         color: '#2f9e44', width: 5,   mode: 'point' },
+  access:      { label: 'Toegang',      color: '#22d3ee', width: 6,   mode: 'point' },
   marking:     { label: 'Markering',    color: '#eab308', width: 0.3, mode: 'line', curved: false },
 };
 
@@ -407,6 +409,27 @@ function drawTree(ctx, s, rpx, index, selected) {
   }
 }
 
+// Access point / entrance marker on the site boundary.
+function drawAccess(ctx, s, rpx, selected) {
+  const r = Math.max(7, rpx * 0.7);
+  ctx.beginPath();
+  ctx.arc(s.x, s.y, r, 0, Math.PI * 2);
+  ctx.fillStyle = '#22d3ee';
+  ctx.fill();
+  ctx.strokeStyle = selected ? '#ffffff' : 'rgba(0,0,0,0.4)';
+  ctx.lineWidth = selected ? 2 : 1;
+  ctx.stroke();
+  ctx.strokeStyle = '#06323a';
+  ctx.lineWidth = Math.max(1.5, r * 0.22);
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  ctx.beginPath();
+  ctx.moveTo(s.x - r * 0.4, s.y + r * 0.18);
+  ctx.lineTo(s.x, s.y - r * 0.35);
+  ctx.lineTo(s.x + r * 0.4, s.y + r * 0.18);
+  ctx.stroke();
+}
+
 // ---- Annotation (infrastructure) rendering ----
 function buildAnnotPath(ctx, pts, curved) {
   ctx.beginPath();
@@ -432,7 +455,8 @@ function drawAnnotation(ctx, ann, w2s, scale, selected, index) {
 
   if (t.mode === 'point') {
     const rpx = Math.max(3, ((ann.width || t.width || 5) / 2) * scale);
-    drawTree(ctx, w2s(ann.points[0]), rpx, index || 0, selected);
+    if (ann.kind === 'access') drawAccess(ctx, w2s(ann.points[0]), rpx, selected);
+    else drawTree(ctx, w2s(ann.points[0]), rpx, index || 0, selected);
     return;
   }
   if (ann.points.length < 2) return;
@@ -786,8 +810,8 @@ function App() {
   }, [buildPlan]);
 
   const metrics = useMemo(
-    () => computeMetrics(doc.site, doc.obstacles, deco, doc.params),
-    [doc.site, doc.obstacles, deco, doc.params]
+    () => computeMetrics(doc.site, doc.obstacles, deco, doc.params, doc.annotations),
+    [doc.site, doc.obstacles, deco, doc.params, doc.annotations]
   );
 
   // ---------- Param helpers ----------
@@ -821,6 +845,22 @@ function App() {
     (doc.site || []).forEach(consider);
     (doc.obstacles || []).forEach((o) => o.forEach(consider));
     return best ? { x: best.x, y: best.y } : s2w(sp);
+  };
+
+  // Closest point on the site boundary (for placing access points).
+  const nearestOnSiteEdge = (wp) => {
+    const site = doc.site;
+    if (!site || site.length < 2) return wp;
+    let best = wp, bestD = Infinity;
+    for (let i = 0; i < site.length; i++) {
+      const a = site[i], b = site[(i + 1) % site.length];
+      const dx = b.x - a.x, dy = b.y - a.y, len2 = dx * dx + dy * dy;
+      let t = len2 ? ((wp.x - a.x) * dx + (wp.y - a.y) * dy) / len2 : 0;
+      t = Math.max(0, Math.min(1, t));
+      const px = a.x + t * dx, py = a.y + t * dy, d = Math.hypot(wp.x - px, wp.y - py);
+      if (d < bestD) { bestD = d; best = { x: px, y: py }; }
+    }
+    return best;
   };
 
   // ---------- Override actions (manual marks) ----------
@@ -1007,7 +1047,11 @@ function App() {
     if (tool === 'annot') {
       const t = ANNOT_TYPES[annotKind];
       const snap = snapPoint(sp);
-      if (t.mode === 'point') { addAnnotation({ kind: annotKind, points: [snap], width: annotWidth }); return; }
+      if (t.mode === 'point') {
+        const at = annotKind === 'access' ? nearestOnSiteEdge(wp) : snap;
+        addAnnotation({ kind: annotKind, points: [at], width: annotWidth });
+        return;
+      }
       if (t.mode === 'area') { dragRef.current = { mode: 'annotArea', start: snap, cur: snap }; return; }
       // line / cross: accumulate points; clicking the first point closes it
       // into a filled area (weg/plein).
@@ -1336,7 +1380,7 @@ function App() {
           </div>
           ${tool === 'annot' && ANNOT_TYPES[annotKind].mode !== 'area' && html`
             <div className="field" style=${{ marginTop: '10px', marginBottom: 0 }}>
-              <label>${ANNOT_TYPES[annotKind].mode === 'point' ? 'Kroondiameter' : 'Breedte'}<span className="val">${annotWidth.toFixed(1)} m</span></label>
+              <label>${annotKind === 'tree' ? 'Kroondiameter' : annotKind === 'access' ? 'Poortbreedte' : 'Breedte'}<span className="val">${annotWidth.toFixed(1)} m</span></label>
               <input type="range" min=${ANNOT_TYPES[annotKind].mode === 'point' ? 1 : 0.2} max=${ANNOT_TYPES[annotKind].mode === 'point' ? 15 : 12} step="0.1" value=${annotWidth}
                 onInput=${(e) => setAnnotWidth(parseFloat(e.target.value))} />
               ${ANNOT_TYPES[annotKind].mode === 'line' && html`
@@ -1472,8 +1516,15 @@ function App() {
             <div className="metric"><div className="k">Site</div><div className="v">${fmt(metrics.siteArea)}<small> m²</small></div></div>
             <div className="metric"><div className="k">Bebouwd</div><div className="v">${(metrics.coverage * 100).toFixed(0)}<small>%</small></div></div>
             <div className="metric"><div className="k">m² / vak</div><div className="v">${metrics.areaPerStall ? metrics.areaPerStall.toFixed(1) : '—'}</div></div>
+            <div className="metric"><div className="k">Verhard</div><div className="v">${(metrics.imperviousPct * 100).toFixed(0)}<small>%</small></div></div>
             <div className="metric"><div className="k">Oriëntaties</div><div className="v">${metrics.orientationCount}</div></div>
           </div>
+          ${metrics.requiredStalls != null && html`<div style=${{ fontSize: '11.5px', color: 'var(--muted)', marginTop: '10px' }}>
+            Zoning-eis: <b style=${{ color: metrics.total >= metrics.requiredStalls ? '#22c55e' : '#f59e0b' }}>${metrics.total}</b> / ${metrics.requiredStalls} vereiste plaatsen.
+          </div>`}
+          ${metrics.accessCount > 0 && html`<div style=${{ fontSize: '11.5px', color: 'var(--muted)', marginTop: '4px' }}>
+            Toegangspunten: <b style=${{ color: 'var(--text)' }}>${metrics.accessCount}</b>.
+          </div>`}
           <div className="legend">
             ${Object.values(STALL_TYPES).map((t) => html`
               <div className="row" key=${t.key}>
@@ -1536,6 +1587,26 @@ function App() {
             <span>ADA-vakken (auto-tabel)</span>
             <input type="checkbox" checked=${doc.params.ada} onChange=${(e) => setParam('ada', e.target.checked)} />
           </div>
+        </div>
+
+        <div className="section">
+          <h3>Programma & parkeer­ratio</h3>
+          <div className="field">
+            <label>Gebouw-GLA<span className="val">${doc.params.buildingGLA || 0} m²</span></label>
+            <input type="number" min="0" step="50" value=${doc.params.buildingGLA || 0}
+              onChange=${(e) => setParam('buildingGLA', Math.max(0, parseFloat(e.target.value) || 0))} />
+          </div>
+          <div className="field">
+            <label>Ratio<span className="val">${doc.params.parkingRatio || 0} / 100 m²</span></label>
+            <input type="number" min="0" step="0.1" value=${doc.params.parkingRatio || 0}
+              onChange=${(e) => setParam('parkingRatio', Math.max(0, parseFloat(e.target.value) || 0))} />
+          </div>
+          ${metrics.requiredStalls != null
+            ? html`<div style=${{ fontSize: '12px', marginTop: '2px' }}>
+                <b style=${{ color: metrics.total >= metrics.requiredStalls ? '#22c55e' : '#f59e0b' }}>${metrics.total}</b>
+                <span style=${{ color: 'var(--muted)' }}> / ${metrics.requiredStalls} vereist — ${metrics.total >= metrics.requiredStalls ? 'voldoet ✓' : (metrics.requiredStalls - metrics.total) + ' tekort'}</span>
+              </div>`
+            : html`<div style=${{ fontSize: '11.5px', color: 'var(--muted)' }}>Vul GLA en ratio in voor een zoning-check.</div>`}
         </div>
       </div>
     </div>

--- a/files/testfit/src/solver.js
+++ b/files/testfit/src/solver.js
@@ -270,7 +270,7 @@ function assignStallTypes(stalls, params) {
 }
 
 /** Aggregate live metrics for the dashboard. */
-export function computeMetrics(site, obstacles, result, params) {
+export function computeMetrics(site, obstacles, result, params, annotations) {
   const siteArea = site && site.length >= 3 ? polygonArea(site) : 0;
   const buildingArea = (obstacles || []).reduce((s, o) => s + polygonArea(o), 0);
   const counts = {};
@@ -283,12 +283,37 @@ export function computeMetrics(site, obstacles, result, params) {
   const areaPerStall = total > 0 ? buildableArea / total : 0;
   const ada = adaRequirement(total);
   const onewayAisles = (result.aisles || []).filter((a) => a.oneway).length;
+
+  // Impervious (paved) coverage: buildings + parking + paved infrastructure,
+  // excluding grass. Capped at the site area (overlaps inflate the raw sum).
+  let paved = buildingArea;
+  for (const st of result.stalls) paved += polygonArea(st.poly);
+  for (const a of result.aisles || []) paved += polygonArea(a.poly);
+  for (const an of annotations || []) {
+    if (!an.points || an.kind === 'grass' || an.kind === 'tree' || an.kind === 'access') continue;
+    if (an.points.length >= 3 && (an.closed || an.kind === 'bikeparking')) paved += polygonArea(an.points);
+    else if (an.points.length >= 2 && (an.kind === 'road' || an.kind === 'walkway' || an.kind === 'bikepath')) {
+      let len = 0;
+      for (let i = 0; i < an.points.length - 1; i++) len += Math.hypot(an.points[i + 1].x - an.points[i].x, an.points[i + 1].y - an.points[i].y);
+      paved += len * (an.width || 1);
+    }
+  }
+  const imperviousPct = siteArea > 0 ? Math.min(1, paved / siteArea) : 0;
+
+  // Zoning parking requirement from building GLA (stalls per 100 m²).
+  const gla = params.buildingGLA || 0;
+  const ratio = params.parkingRatio || 0;
+  const requiredStalls = gla > 0 && ratio > 0 ? Math.ceil((gla / 100) * ratio) : null;
+  const accessCount = (annotations || []).filter((a) => a.kind === 'access').length;
+
   return {
     siteArea, buildingArea, buildableArea, total, counts,
     areaPerStall,
     coverage: siteArea > 0 ? buildingArea / siteArea : 0,
+    imperviousPct,
     adaRequired: ada.required, adaVan: ada.van,
     adaProvided: counts.ada || 0,
+    requiredStalls, accessCount,
     orientationCount: result.orientationCount || 0,
     aisleCount: (result.aisles || []).length, onewayAisles,
   };


### PR DESCRIPTION
Stage K: extra TestFit-pariteit.

- **Parkeerratio-calculator**: nieuw paneel "Programma & parkeerratio" — voer gebouw-**GLA** (m²) en **ratio** (plaatsen per 100 m²) in; toont **geleverd vs. vereist** met voldoet/tekort-indicatie.
- **Verhard/impervious %**: nieuwe metric-tegel — gebouwen + parkeren + verharde infrastructuur (excl. gras), begrensd op de site.
- **Toegangspunten**: nieuw "Toegang"-gereedschap plaatst in-/uitrit-markers die **aan de site-rand snappen**; geteld in de metrics.

`computeMetrics` uitgebreid met `imperviousPct`, `requiredStalls` en `accessCount`.

## Getest
Node (impervious %, vereiste plaatsen = GLA/100×ratio, access-telling) en headless Chromium (toegangspunt snapt op de site-rand, "Verhard 63%"-tegel + "Toegangspunten: 1"). Geen console-errors.

Hiermee is de volledige roadmap-batch (export, worker, single-loaded/dead-end, pin/lock, 2.5D, ratio/verhard/toegang) klaar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_