### PR TITLE
ParkPlanner: parkeervakken volgen de bochten (concentrische layout)

### DIFF
--- a/files/testfit/README.md
+++ b/files/testfit/README.md
@@ -22,6 +22,11 @@ rijstroken en metrics — geïnspireerd op TestFit's *Parking Solver*.
   zebrapaden, fietsparking (met capaciteit), **gras**, **bomen** en markeringen.
   Wegen/paden **snappen** aan bestaande hoekpunten en kunnen tot een **gesloten
   vlak/plein** worden gesloten; **afmetingen** verschijnen live tijdens het tekenen.
+- **Gebogen site-grenzen** — teken multipoint-sites en zet "Vloeiende bochten"
+  aan; de solver plaatst automatisch vakken in de curves.
+- **Handmatig vakken plaatsen** — "Vak +" (K) plaatst vakken die aan bestaande
+  vakken snappen; selecteer vakken en verwijder ze (Delete). Verwijderde
+  solver-vakken blijven weg bij her-solve.
 - **Site verplaatsen/verwijderen** — klik de site-rand om de hele site te
   selecteren, sleep om te verplaatsen, Delete om te verwijderen.
 - **Navigatie** — twee-vinger trackpad pant, pinch/Ctrl+scroll zoomt.

--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -67,8 +67,9 @@ export const ANNOT_TYPES = {
 const initialDoc = {
   site: DEFAULT_SITE, siteCurved: false, obstacles: DEFAULT_OBSTACLES, geo: DEFAULT_GEO,
   params: DEFAULT_PARAMS, orientationIndex: 0,
-  overrides: { stalls: {}, aisles: {}, locks: { stalls: {}, aisles: {} } },
+  overrides: { stalls: {}, aisles: {}, locks: { stalls: {}, aisles: {} }, removed: {} },
   annotations: [], // { kind, points:[{x,y}], width, curved }
+  manualStalls: [], // hand-placed stalls: { poly, type }
 };
 
 // Simple history wrapper: { past[], present, future[] }.
@@ -241,6 +242,16 @@ function draw(ctx, opts) {
   // Infrastructure drawn over the parking (paths, crosswalks, markings)
   if (layers.infra && doc.annotations) {
     drawAnnotations(ctx, doc.annotations, w2s, view.scale, false, selAnnIdx);
+  }
+
+  // Manual stall placement preview
+  if (hover && hover.stallPreview) {
+    pathPoly(ctx, hover.stallPreview, w2s, true);
+    ctx.fillStyle = 'rgba(34,197,94,0.35)';
+    ctx.fill();
+    ctx.strokeStyle = '#22c55e';
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
   }
 
   // Rectangle preview (obstacle / bike-parking area drag) with dimensions
@@ -750,17 +761,23 @@ function App() {
     const ov = doc.overrides || {};
     const ovStalls = ov.stalls || {}, ovAisles = ov.aisles || {};
     const locks = ov.locks || {}, lockS = locks.stalls || {}, lockA = locks.aisles || {};
+    const removed = ov.removed || {};
     const stalls = result.stalls.map((st) => {
       const key = stallKey(st.poly);
-      return { ...st, key, type: ovStalls[key] || st.type, locked: !!lockS[key] };
-    });
+      return { ...st, key, type: ovStalls[key] || st.type, locked: !!lockS[key], manual: false };
+    }).filter((st) => !removed[st.key]);
+    // Hand-placed stalls, markable/lockable like solver stalls.
+    for (const ms of doc.manualStalls || []) {
+      const key = stallKey(ms.poly);
+      stalls.push({ poly: ms.poly, key, type: ovStalls[key] || ms.type || 'standard', locked: !!lockS[key], manual: true });
+    }
     const aisles = result.aisles.map((q) => {
       const key = aisleKey(q);
       const o = ovAisles[key] || {};
       return { poly: q, key, oneway: !!o.oneway, dir: o.dir || 1, locked: !!lockA[key] };
     });
     return { stalls, aisles, orientationCount: result.orientationCount };
-  }, [result, doc.overrides]);
+  }, [result, doc.overrides, doc.manualStalls]);
 
   const renderNow = useCallback(() => {
     const canvas = canvasRef.current;
@@ -878,6 +895,7 @@ function App() {
     return {
       stalls: { ...o.stalls }, aisles: { ...o.aisles },
       locks: { stalls: { ...l.stalls }, aisles: { ...l.aisles } },
+      removed: { ...o.removed },
     };
   };
   const setStallTypes = (keys, type) => dispatch({ type: 'COMMIT', updater: (d) => {
@@ -910,6 +928,44 @@ function App() {
     return { ...d, overrides: ov };
   } });
   const clearSel = () => { setStallSel([]); setAisleSel(null); setSelection(null); };
+
+  // ---------- Manual stall placement + delete ----------
+  const stallAt = (center, theta) => {
+    const w = doc.params.stallWidth, d = doc.params.stallDepth;
+    const c = Math.cos(theta), s = Math.sin(theta);
+    const ux = c, uy = s, vx = -s, vy = c, hw = w / 2, hd = d / 2;
+    return [
+      { x: center.x - ux * hw - vx * hd, y: center.y - uy * hw - vy * hd },
+      { x: center.x + ux * hw - vx * hd, y: center.y + uy * hw - vy * hd },
+      { x: center.x + ux * hw + vx * hd, y: center.y + uy * hw + vy * hd },
+      { x: center.x - ux * hw + vx * hd, y: center.y - uy * hw + vy * hd },
+    ];
+  };
+  // Snap a click to the lattice of the nearest existing stall (so hand-placed
+  // stalls tile next to solver stalls); otherwise a coarse metric grid.
+  const snapStallCenter = (click) => {
+    const theta = result.angleUsed || 0;
+    const w = doc.params.stallWidth, d = doc.params.stallDepth;
+    const ux = Math.cos(theta), uy = Math.sin(theta), vx = -Math.sin(theta), vy = Math.cos(theta);
+    let best = null, bestD = Infinity;
+    for (const st of deco.stalls) { const ct = polygonCentroid(st.poly); const dd = dist(ct, click); if (dd < bestD) { bestD = dd; best = ct; } }
+    if (best && bestD < 3 * Math.max(w, d)) {
+      const dx = click.x - best.x, dy = click.y - best.y;
+      const su = Math.round((dx * ux + dy * uy) / w) * w;
+      const sv = Math.round((dx * vx + dy * vy) / d) * d;
+      return { x: best.x + su * ux + sv * vx, y: best.y + su * uy + sv * vy };
+    }
+    return { x: Math.round(click.x * 4) / 4, y: Math.round(click.y * 4) / 4 };
+  };
+  const addManualStall = (poly) =>
+    dispatch({ type: 'COMMIT', updater: (d) => ({ ...d, manualStalls: [...(d.manualStalls || []), { poly, type: 'standard' }] }) });
+  const deleteStalls = (keys) => dispatch({ type: 'COMMIT', updater: (d) => {
+    const manualKeys = new Set((d.manualStalls || []).map((ms) => stallKey(ms.poly)));
+    const keep = (d.manualStalls || []).filter((ms) => !keys.includes(stallKey(ms.poly)));
+    const ov = ovOf(d);
+    for (const k of keys) { if (!manualKeys.has(k)) ov.removed[k] = 1; }
+    return { ...d, manualStalls: keep, overrides: ov };
+  } });
 
   // ---------- Annotation (infrastructure) actions ----------
   const addAnnotation = (ann) =>
@@ -991,6 +1047,11 @@ function App() {
     // Middle-button or pan tool → pan.
     if (e.button === 1 || tool === 'pan') {
       dragRef.current = { mode: 'pan', start: sp, view: { ...view } };
+      return;
+    }
+
+    if (tool === 'placestall') {
+      addManualStall(stallAt(snapStallCenter(wp), result.angleUsed || 0));
       return;
     }
 
@@ -1083,6 +1144,7 @@ function App() {
 
     if (!drag) {
       if ((tool === 'site' || tool === 'annot') && drawing) setHover(snapPoint(sp));
+      else if (tool === 'placestall') setHover({ stallPreview: stallAt(snapStallCenter(wp), result.angleUsed || 0) });
       return;
     }
     if (drag.mode === 'pan') {
@@ -1201,13 +1263,16 @@ function App() {
         case 'v': setTool('select'); break;
         case 'p': setTool('site'); setDrawing({ points: [] }); break;
         case 'b': setTool('obstacle'); break;
+        case 'k': setTool('placestall'); break;
         case ' ': setTool('pan'); break;
         case 'g': setLayers((l) => ({ ...l, grid: !l.grid })); break;
         case '+': case '=': zoomBy(1.2); break;
         case '-': case '_': zoomBy(1 / 1.2); break;
         case 'escape': setDrawing(null); setTool('select'); setSelection(null); setStallSel([]); setAisleSel(null); break;
         case 'delete': case 'backspace':
-          if (selection && selection.type === 'obs') {
+          if (stallSel.length) {
+            deleteStalls(stallSel); setStallSel([]);
+          } else if (selection && selection.type === 'obs') {
             dispatch({ type: 'COMMIT', updater: (d) => ({ ...d, obstacles: d.obstacles.filter((_, i) => i !== selection.index) }) });
             setSelection(null);
           } else if (selection && selection.type === 'annot') {
@@ -1221,7 +1286,7 @@ function App() {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [selection]);
+  }, [selection, stallSel]);
 
   // ---------- Toolbar actions ----------
   const cycleAxis = () =>
@@ -1311,6 +1376,7 @@ function App() {
     site: 'Klik om punten te plaatsen · klik het eerste punt of dubbelklik om te sluiten · Esc annuleert',
     obstacle: 'Sleep een rechthoek voor een gebouw / uitsluitingszone',
     pan: 'Sleep om te verschuiven',
+    placestall: 'Klik om een parkeervak te plaatsen (snapt aan bestaande vakken) · Esc stopt',
     annot: ANNOT_TYPES[annotKind] && ANNOT_TYPES[annotKind].mode === 'point'
       ? `${ANNOT_TYPES[annotKind].label}: klik om te plaatsen · Esc stopt`
       : ANNOT_TYPES[annotKind] && ANNOT_TYPES[annotKind].mode === 'area'
@@ -1332,6 +1398,7 @@ function App() {
         ${toolBtn('select', 'Selecteer', 'V', tool, setTool, setDrawing)}
         ${toolBtn('site', 'Site', 'P', tool, setTool, setDrawing)}
         ${toolBtn('obstacle', 'Gebouw', 'B', tool, setTool, setDrawing)}
+        ${toolBtn('placestall', 'Vak +', 'K', tool, setTool, setDrawing)}
         ${toolBtn('pan', 'Pan', '␣', tool, setTool, setDrawing)}
         <button className="btn ghost" onClick=${newRect}>Nieuwe site</button>
         <div className="tb-sep"></div>
@@ -1502,10 +1569,11 @@ function App() {
             ${(() => {
               const lockedSet = (doc.overrides.locks && doc.overrides.locks.stalls) || {};
               const allLocked = stallSel.every((k) => lockedSet[k]);
-              return html`<div className="sel-actions">
-                <button className="btn ghost" onClick=${() => setStallTypes(stallSel, null)}>↺ Wis markering</button>
-                <button className="btn ghost" onClick=${() => toggleLockStalls(stallSel, !allLocked)}>${allLocked ? '🔓 Ontgrendel' : '🔒 Vergrendel'}</button>
-                <button className="btn ghost" onClick=${clearSel}>Deselecteer</button>
+              return html`<div className="sel-actions" style=${{ flexWrap: 'wrap' }}>
+                <button className="btn ghost" onClick=${() => setStallTypes(stallSel, null)}>↺ Wis</button>
+                <button className="btn ghost" onClick=${() => toggleLockStalls(stallSel, !allLocked)}>${allLocked ? '🔓' : '🔒'}</button>
+                <button className="btn ghost" onClick=${() => { deleteStalls(stallSel); setStallSel([]); }}>🗑 Verwijder</button>
+                <button className="btn ghost" onClick=${clearSel}>✕</button>
               </div>`;
             })()}
           `}

--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -31,6 +31,7 @@ const DEFAULT_PARAMS = {
   compactRatio: 0, evRatio: 0.05, ada: true,
   singleLoaded: false, deadEndTurnaround: false, turnaround: 7,
   buildingGLA: 0, parkingRatio: 0, // GLA (m²) + stalls per 100 m² (zoning)
+  layout: 'strip', // 'strip' (straight rows) | 'perimeter' (follows the curve)
 };
 
 // Default demo site: an L-shaped parcel (rectangle with a building in the corner).
@@ -1628,6 +1629,13 @@ function App() {
 
         <div className="section">
           <h3>Vak & rijstrook</h3>
+          <div className="field">
+            <label>Layout</label>
+            <div className="seg">
+              <button className=${(doc.params.layout || 'strip') === 'strip' ? 'active' : ''} onClick=${() => setParam('layout', 'strip')}>Rechte rijen</button>
+              <button className=${doc.params.layout === 'perimeter' ? 'active' : ''} onClick=${() => setParam('layout', 'perimeter')}>Volgt de rand</button>
+            </div>
+          </div>
           ${slider('Vakbreedte', 'stallWidth', doc.params.stallWidth, 2.2, 3.5, 0.1, 'm', setParam)}
           ${slider('Vakdiepte', 'stallDepth', doc.params.stallDepth, 4.5, 6.5, 0.1, 'm', setParam)}
           ${slider('Rijstrook', 'aisleWidth', doc.params.aisleWidth, 5, 8, 0.1, 'm', setParam)}

--- a/files/testfit/src/solver.js
+++ b/files/testfit/src/solver.js
@@ -143,6 +143,11 @@ export function solveParking(site, obstacles, params, orientationIndex = 0) {
   }
   if (angleSet.length === 0) angleSet.push(0);
 
+  // Perimeter / concentric layout: rows follow the boundary curve.
+  if (params.layout === 'perimeter') {
+    return { ...packConcentric(buildable, blockers, params), orientationCount: 1 };
+  }
+
   // Pack once per orientation; rank by stall count.
   const results = angleSet.map((theta) =>
     packOrientation(buildable, blockers, params, theta)
@@ -151,6 +156,95 @@ export function solveParking(site, obstacles, params, orientationIndex = 0) {
 
   const chosen = results[Math.min(orientationIndex, results.length - 1)] || empty;
   return { ...chosen, orientationCount: results.length };
+}
+
+// Sample a polygon perimeter every `step`, returning points with an inward
+// unit normal (oriented toward `interior`). Used for curved parking rows.
+function sampleRing(poly, step, interior) {
+  const out = [];
+  const n = poly.length;
+  let carry = 0; // distance already consumed into the current edge
+  for (let i = 0; i < n; i++) {
+    const a = poly[i], b = poly[(i + 1) % n];
+    const ex = b.x - a.x, ey = b.y - a.y, len = Math.hypot(ex, ey);
+    if (len < 1e-9) continue;
+    const ux = ex / len, uy = ey / len;
+    let nx = -uy, ny = ux;
+    const mx = (a.x + b.x) / 2, my = (a.y + b.y) / 2;
+    if ((interior.x - mx) * nx + (interior.y - my) * ny < 0) { nx = -nx; ny = -ny; }
+    let dpos = carry;
+    while (dpos <= len + 1e-9) {
+      out.push({ x: a.x + ux * dpos, y: a.y + uy * dpos, nx, ny });
+      dpos += step;
+    }
+    carry = dpos - len; // leftover carried into the next edge
+  }
+  return out;
+}
+
+/**
+ * Concentric / perimeter parking: offset the boundary inward in
+ * double-loaded modules and lay curved rows of stalls (perpendicular to
+ * the boundary) that follow the site's curves, with curved drive aisles.
+ */
+function packConcentric(buildable, blockers, params) {
+  const w = params.stallWidth, d = params.stallDepth, aisle = params.aisleWidth;
+  const moduleH = 2 * d + aisle;
+  const interior = polygonCentroid(buildable);
+  const stalls = [], aisles = [];
+  const centroids = []; // for overlap rejection (e.g. at sharp corners)
+  const minSep = 0.6 * Math.min(w, d);
+  const overlaps = (cx, cy) => centroids.some((c) => Math.hypot(c.x - cx, c.y - cy) < minSep);
+
+  // Lay a curved band of stalls whose outer edge is offset(poly, outerInset),
+  // extending inward by depth `dep`.
+  const band = (outerInset, dep, collect, isStall) => {
+    const ring = outerInset === 0 ? buildable : offsetPolygon(buildable, outerInset);
+    if (!ring || polygonArea(ring) < 4) return 0;
+    const samples = sampleRing(ring, w, interior);
+    let placed = 0;
+    for (let i = 0; i < samples.length - 1; i++) {
+      const p0 = samples[i], p1 = samples[i + 1];
+      // Skip the wrap seam where consecutive samples jump far apart.
+      if (Math.hypot(p1.x - p0.x, p1.y - p0.y) > w * 2.2) continue;
+      const quad = [
+        { x: p0.x, y: p0.y },
+        { x: p1.x, y: p1.y },
+        { x: p1.x + p1.nx * dep, y: p1.y + p1.ny * dep },
+        { x: p0.x + p0.nx * dep, y: p0.y + p0.ny * dep },
+      ];
+      const cx = (quad[0].x + quad[1].x + quad[2].x + quad[3].x) / 4;
+      const cy = (quad[0].y + quad[1].y + quad[2].y + quad[3].y) / 4;
+      if (isStall && overlaps(cx, cy)) continue;
+      // The outer corners hug the boundary (unreliable for point-in-polygon),
+      // so validate the interior side: centre + inner-edge midpoint inside.
+      const imx = (quad[2].x + quad[3].x) / 2, imy = (quad[2].y + quad[3].y) / 2;
+      if (!pointInPolygon({ x: cx, y: cy }, buildable)) continue;
+      if (!pointInPolygon({ x: imx, y: imy }, buildable)) continue;
+      if (blockers.some((b) => quadIntersectsPolygon(quad, b))) continue;
+      if (isStall) centroids.push({ x: cx, y: cy });
+      collect.push(quad);
+      placed++;
+    }
+    return placed;
+  };
+
+  for (let k = 0; k < 60; k++) {
+    const o0 = k * moduleH;
+    const outer = [];
+    const inner = [];
+    const aq = [];
+    const nOuter = band(o0, d, outer, true);
+    band(o0 + d, aisle, aq, false);          // curved drive aisle band
+    const nInner = band(o0 + d + aisle, d, inner, true);
+    if (nOuter === 0 && nInner === 0) break;
+    for (const q of outer) stalls.push({ poly: q, type: 'standard' });
+    for (const q of inner) stalls.push({ poly: q, type: 'standard' });
+    if (nOuter > 0 || nInner > 0) for (const q of aq) aisles.push(q);
+  }
+
+  assignStallTypes(stalls, params);
+  return { stalls, aisles, angleUsed: 0 };
 }
 
 /**


### PR DESCRIPTION
Nieuwe layout-modus zodat de **parkeervakken zelf de bochten volgen** (i.p.v. rechte rijen die bij de rand worden afgekapt).

Onder **Vak & rijstrook → "Volgt de rand"**: `packConcentric` offset de rand telkens naar binnen in dubbel-belaste modules en legt **gebogen rijen trapezium-vakken** die de curve van de site volgen, met gebogen rijstroken ertussen (stadion-/perimeter-stijl).

- `sampleRing` loopt een ring af op booglengte en geeft punten met naar-binnen-normalen; elk vak beslaat één vakbreedte langs de ring en steekt de vakdiepte naar binnen, zodat vakken langs de curve uitwaaieren.
- Validatie via vak-centrum + binnenrand (buitenhoeken liggen op de rand waar point-in-polygon onbetrouwbaar is); hoek-overlappingen worden op centroïde-afstand afgewezen.
- `params.layout`: `'strip'` (standaard, rechte rijen) | `'perimeter'`.

## Getest
Node (zeshoek 125, gebogen zevenhoek) en headless Chromium: een gebogen site levert een nette perimeter-ring van ~69 vakken die de rand volgen; rechthoek/strip-standaard ongewijzigd. Geen console-errors. Screenshot bevestigt de curve-volgende ring.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_