### PR TITLE
ParkPlanner: metrics summary popup, motorcycle = 3 spaces, align to site edge

### DIFF
--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -4,7 +4,7 @@
 import React, { useReducer, useRef, useState, useEffect, useCallback, useMemo } from '../vendor/react.mjs';
 import { createRoot } from '../vendor/react-dom-client.mjs';
 import htm from '../vendor/htm.mjs';
-import { solveParking, computeMetrics, STALL_TYPES, stallKey, aisleKey, aisleAxis } from './solver.js';
+import { solveParking, computeMetrics, STALL_TYPES, stallKey, aisleKey, aisleAxis, longestEdgeAngle } from './solver.js';
 import {
   offsetPolygon, boundingBox, polygonCentroid, polygonArea, dist, distPointSegment,
   pointInPolygon, rectPoly, tessellateClosed,
@@ -32,6 +32,7 @@ const DEFAULT_PARAMS = {
   singleLoaded: false, deadEndTurnaround: false, turnaround: 7,
   buildingGLA: 0, parkingRatio: 0, // GLA (m²) + stalls per 100 m² (zoning)
   layout: 'strip', // 'strip' (straight rows) | 'perimeter' (follows the curve)
+  alignLongestEdge: false, // align rows to the site's longest edge
 };
 
 // Default demo site: an L-shaped parcel (rectangle with a building in the corner).
@@ -226,6 +227,16 @@ function draw(ctx, opts) {
         ctx.lineWidth = 1.4;
         ctx.stroke();
         ctx.setLineDash([]);
+      }
+      if (st.type === 'motorcycle') { // subdivide into 3 motorcycle bays
+        const p = st.poly;
+        ctx.strokeStyle = 'rgba(255,255,255,0.85)';
+        ctx.lineWidth = 0.8;
+        for (const t of [1 / 3, 2 / 3]) {
+          const a = w2s({ x: p[0].x + (p[1].x - p[0].x) * t, y: p[0].y + (p[1].y - p[0].y) * t });
+          const b = w2s({ x: p[3].x + (p[2].x - p[3].x) * t, y: p[3].y + (p[2].y - p[3].y) * t });
+          ctx.beginPath(); ctx.moveTo(a.x, a.y); ctx.lineTo(b.x, b.y); ctx.stroke();
+        }
       }
       if (showGlyph && info.glyph) {
         const s = w2s(polygonCentroid(st.poly));
@@ -670,6 +681,7 @@ function App() {
   const [mbTokenInput, setMbTokenInput] = useState('');
   const [map3dError, setMap3dError] = useState('');
   const [exportOpen, setExportOpen] = useState(false);
+  const [summaryOpen, setSummaryOpen] = useState(false);
 
   const wrapRef = useRef(null);
   const canvasRef = useRef(null);
@@ -743,7 +755,11 @@ function App() {
     clearTimeout(solveTimer.current);
     setSolving(true);
     solveTimer.current = setTimeout(() => {
-      const args = [sitePoly, doc.obstacles, doc.params, doc.orientationIndex];
+      // Align rows to the site's longest (control-point) edge when requested.
+      const solveP = doc.params.alignLongestEdge && doc.site.length >= 2
+        ? { ...doc.params, alignAngle: longestEdgeAngle(doc.site) }
+        : doc.params;
+      const args = [sitePoly, doc.obstacles, solveP, doc.orientationIndex];
       lastArgsRef.current = args;
       const reqId = ++reqRef.current;
       if (workerRef.current) {
@@ -1602,7 +1618,10 @@ function App() {
           })()}
         </div>`}
         <div className="section">
-          <h3>Metrics</h3>
+          <h3 style=${{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span>Metrics</span>
+            <button className="btn ghost" style=${{ padding: '3px 8px', fontSize: '11px' }} onClick=${() => setSummaryOpen(true)}>📋 Samenvatting</button>
+          </h3>
           <div className="metric-grid">
             <div className="metric big"><div className="k">Totaal vakken</div><div className="v">${metrics.total}</div></div>
             <div className="metric"><div className="k">Site</div><div className="v">${fmt(metrics.siteArea)}<small> m²</small></div></div>
@@ -1642,6 +1661,10 @@ function App() {
               <button className=${doc.params.layout === 'hybrid' ? 'active' : ''} onClick=${() => setParam('layout', 'hybrid')} title="Rand volgt de curve + recht in het midden">Rand+midden</button>
               <button className=${doc.params.layout === 'perimeter' ? 'active' : ''} onClick=${() => setParam('layout', 'perimeter')} title="Volledig concentrisch, volgt de rand">Concentrisch</button>
             </div>
+          </div>
+          <div className="toggle">
+            <span>Lijn rijen uit met langste rand</span>
+            <input type="checkbox" checked=${!!doc.params.alignLongestEdge} onChange=${(e) => setParam('alignLongestEdge', e.target.checked)} />
           </div>
           ${slider('Vakbreedte', 'stallWidth', doc.params.stallWidth, 2.2, 3.5, 0.1, 'm', setParam)}
           ${slider('Vakdiepte', 'stallDepth', doc.params.stallDepth, 4.5, 6.5, 0.1, 'm', setParam)}
@@ -1709,6 +1732,49 @@ function App() {
             : html`<div style=${{ fontSize: '11.5px', color: 'var(--muted)' }}>Vul GLA en ratio in voor een zoning-check.</div>`}
         </div>
       </div>
+
+      ${summaryOpen && html`
+        <div className="modal-backdrop" onClick=${() => setSummaryOpen(false)}>
+          <div className="modal" onClick=${(e) => e.stopPropagation()}>
+            <h3 style=${{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 0 }}>
+              <span>Samenvatting</span>
+              <button className="btn ghost" style=${{ padding: '2px 8px' }} onClick=${() => setSummaryOpen(false)}>✕</button>
+            </h3>
+            <div className="sum-h">Parkeerplaatsen per type</div>
+            <table className="sum-table">
+              ${Object.values(STALL_TYPES).map((t) => (metrics.counts[t.key] > 0) ? html`
+                <tr key=${t.key}>
+                  <td><span className="dot" style=${{ background: t.color, display: 'inline-block', width: '10px', height: '10px', borderRadius: '3px', marginRight: '6px' }}></span>${t.label}${t.spaces ? ` (${t.spaces}/vak)` : ''}</td>
+                  <td>${metrics.counts[t.key]}</td>
+                </tr>` : '')}
+              <tr className="sum-tot"><td>Totaal plaatsen</td><td>${metrics.total}</td></tr>
+              <tr><td>Fysieke vakken</td><td>${metrics.physicalStalls}</td></tr>
+            </table>
+            <div className="sum-h">Oppervlaktes</div>
+            <table className="sum-table">
+              <tr><td>Site</td><td>${fmt(metrics.siteArea)} m²</td></tr>
+              <tr><td>Bebouwd</td><td>${fmt(metrics.buildingArea)} m² · ${(metrics.coverage * 100).toFixed(0)}%</td></tr>
+              <tr><td>Beschikbaar</td><td>${fmt(metrics.buildableArea)} m²</td></tr>
+              <tr><td>m² per vak</td><td>${metrics.areaPerStall ? metrics.areaPerStall.toFixed(1) : '—'}</td></tr>
+              <tr><td>Verhard</td><td>${(metrics.imperviousPct * 100).toFixed(0)}%</td></tr>
+            </table>
+            <div className="sum-h">Toegankelijkheid & circulatie</div>
+            <table className="sum-table">
+              <tr><td>Minder-valide</td><td>${metrics.adaProvided} / ${metrics.adaRequired} vereist · ${metrics.adaVan} van</td></tr>
+              <tr><td>Rijstroken</td><td>${metrics.aisleCount} · ${metrics.onewayAisles} eenrichting</td></tr>
+              <tr><td>Toegangspunten</td><td>${metrics.accessCount}</td></tr>
+              <tr><td>Oriëntaties</td><td>${metrics.orientationCount}</td></tr>
+            </table>
+            ${metrics.requiredStalls != null && html`
+              <div className="sum-h">Zoning</div>
+              <table className="sum-table">
+                <tr><td>Geleverd / vereist</td><td>${metrics.total} / ${metrics.requiredStalls}${metrics.total >= metrics.requiredStalls ? ' ✓' : ''}</td></tr>
+              </table>`}
+            <div className="sel-actions" style=${{ marginTop: '14px' }}>
+              <button className="btn" onClick=${() => setSummaryOpen(false)}>Sluiten</button>
+            </div>
+          </div>
+        </div>`}
     </div>
   `;
 }

--- a/files/testfit/src/solver.js
+++ b/files/testfit/src/solver.js
@@ -50,7 +50,7 @@ export const STALL_TYPES = {
   staff:      { key: 'staff',      label: 'Personeel',    color: '#f59e0b', glyph: 'P' },
   visitor:    { key: 'visitor',    label: 'Bezoeker',     color: '#ec4899', glyph: 'B' },
   reserved:   { key: 'reserved',   label: 'Gereserveerd', color: '#ef4444', glyph: 'R' },
-  motorcycle: { key: 'motorcycle', label: 'Motor',        color: '#a855f7', glyph: 'M' },
+  motorcycle: { key: 'motorcycle', label: 'Motor',        color: '#a855f7', glyph: 'M', spaces: 3 },
 };
 
 // Stable position keys so manual overrides survive re-solves. Stalls are
@@ -133,19 +133,38 @@ export function solveParking(site, obstacles, params, orientationIndex = 0) {
   return packStripBest(buildable, blockers, params, orientationIndex);
 }
 
+/** Direction (rad, in [0,PI)) of the longest edge of a polygon. */
+export function longestEdgeAngle(poly) {
+  let best = 0, bestLen = -1;
+  for (let i = 0, n = poly.length; i < n; i++) {
+    const a = poly[i], b = poly[(i + 1) % n];
+    const len = Math.hypot(b.x - a.x, b.y - a.y);
+    if (len > bestLen) { bestLen = len; best = Math.atan2(b.y - a.y, b.x - a.x); }
+  }
+  return ((best % Math.PI) + Math.PI) % Math.PI;
+}
+
 // Straight strip packing across candidate orientations; returns the best.
 // Orientations = each edge direction (+ normal), deduped ~2° and capped so a
 // many-vertex spline boundary doesn't explode into hundreds of them.
+// If params.alignAngle is set, only that angle (+ its normal) is tried, so
+// rows line up with the chosen site edge.
 function packStripBest(buildable, blockers, params, orientationIndex = 0) {
-  const base = edgeAngles(buildable);
-  const TOL = 0.035, CAP = 40;
-  const angleSet = [];
-  for (const a of base) {
-    for (const cand of [a, a + Math.PI / 2]) {
-      const norm = ((cand % Math.PI) + Math.PI) % Math.PI;
-      if (!angleSet.some((x) => Math.abs(x - norm) < TOL || Math.abs(x - norm) > Math.PI - TOL)) angleSet.push(norm);
+  let angleSet;
+  if (typeof params.alignAngle === 'number') {
+    const a = ((params.alignAngle % Math.PI) + Math.PI) % Math.PI;
+    angleSet = [a, ((a + Math.PI / 2) % Math.PI + Math.PI) % Math.PI];
+  } else {
+    const base = edgeAngles(buildable);
+    const TOL = 0.035, CAP = 40;
+    angleSet = [];
+    for (const a of base) {
+      for (const cand of [a, a + Math.PI / 2]) {
+        const norm = ((cand % Math.PI) + Math.PI) % Math.PI;
+        if (!angleSet.some((x) => Math.abs(x - norm) < TOL || Math.abs(x - norm) > Math.PI - TOL)) angleSet.push(norm);
+      }
+      if (angleSet.length >= CAP) break;
     }
-    if (angleSet.length >= CAP) break;
   }
   if (angleSet.length === 0) angleSet.push(0);
   const results = angleSet.map((theta) => packOrientation(buildable, blockers, params, theta));
@@ -388,15 +407,17 @@ function assignStallTypes(stalls, params) {
 export function computeMetrics(site, obstacles, result, params, annotations) {
   const siteArea = site && site.length >= 3 ? polygonArea(site) : 0;
   const buildingArea = (obstacles || []).reduce((s, o) => s + polygonArea(o), 0);
+  // Counts are in parking *spaces*: a motorcycle stall provides 3 spaces.
   const counts = {};
   for (const k of Object.keys(STALL_TYPES)) counts[k] = 0;
-  for (const st of result.stalls) counts[st.type] = (counts[st.type] || 0) + 1;
-  const total = result.stalls.length;
+  for (const st of result.stalls) counts[st.type] = (counts[st.type] || 0) + (STALL_TYPES[st.type] ? STALL_TYPES[st.type].spaces || 1 : 1);
+  const physicalStalls = result.stalls.length;               // stall footprints
+  const total = Object.values(counts).reduce((a, b) => a + b, 0); // spaces (motor ×3)
   const buildable = computeBuildable(site, params.setback);
   const buildableArea = buildable ? polygonArea(buildable) : 0;
-  // Gross area per stall (lower is a denser, more efficient layout).
-  const areaPerStall = total > 0 ? buildableArea / total : 0;
-  const ada = adaRequirement(total);
+  // Gross area per stall footprint (lower is a denser, more efficient layout).
+  const areaPerStall = physicalStalls > 0 ? buildableArea / physicalStalls : 0;
+  const ada = adaRequirement(physicalStalls);
   const onewayAisles = (result.aisles || []).filter((a) => a.oneway).length;
 
   // Impervious (paved) coverage: buildings + parking + paved infrastructure,
@@ -422,7 +443,7 @@ export function computeMetrics(site, obstacles, result, params, annotations) {
   const accessCount = (annotations || []).filter((a) => a.kind === 'access').length;
 
   return {
-    siteArea, buildingArea, buildableArea, total, counts,
+    siteArea, buildingArea, buildableArea, total, physicalStalls, counts,
     areaPerStall,
     coverage: siteArea > 0 ? buildingArea / siteArea : 0,
     imperviousPct,

--- a/files/testfit/styles.css
+++ b/files/testfit/styles.css
@@ -360,6 +360,39 @@ select.preset {
 .legend .dot { width: 11px; height: 11px; border-radius: 3px; }
 .legend .row .count { margin-left: auto; font-variant-numeric: tabular-nums; color: var(--muted); }
 
+/* ---- Modal (summary) ---- */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.55);
+  display: grid;
+  place-items: center;
+}
+.modal {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 18px 20px 16px;
+  width: min(92%, 440px);
+  max-height: 84vh;
+  overflow-y: auto;
+  box-shadow: var(--shadow);
+}
+.modal h3 { font-size: 15px; }
+.sum-h {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 14px 0 6px;
+}
+.sum-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.sum-table td { padding: 4px 0; border-bottom: 1px solid var(--border); }
+.sum-table td:last-child { text-align: right; font-variant-numeric: tabular-nums; color: var(--text); }
+.sum-table td:first-child { color: var(--muted); }
+.sum-table tr.sum-tot td { font-weight: 700; color: var(--text); border-bottom: 2px solid var(--border); }
+
 /* ---- Selection panel ---- */
 .sel-section { background: #131a24; border-bottom: 1px solid var(--border); }
 .sel-section h3 { color: var(--accent); }


### PR DESCRIPTION
## Summary

Three parking-planner improvements requested by the user:

- **Metrics summary popup** — the Metrics section gets a `📋 Samenvatting` button that opens a modal listing every parking type with its count, physical vs. total spaces, area breakdown, accessibility/circulation figures and zoning metrics.
- **Motorcycle stalls count as 3** — a stall marked as `motorcycle` now renders 3 sub-bays visually and is counted as 3 spaces in all metrics (`physicalStalls` vs `total`).
- **Align to site edge** — a new toggle aligns parking rows with the longest edge of the site (`alignLongestEdge` → `alignAngle` from `longestEdgeAngle(site)`).

## Changes
- `files/testfit/src/solver.js` — `STALL_TYPES.motorcycle.spaces = 3`; `computeMetrics` counts spaces and reports `physicalStalls`; new `longestEdgeAngle()`; `packStripBest` honors `params.alignAngle`.
- `files/testfit/src/app.js` — summary modal, motorcycle 3-bay dividers in `draw()`, align-to-edge toggle wiring.
- `files/testfit/styles.css` — modal styles.

## Verification
- Node: `counts {... motorcycle: 3}`, total spaces 5, physical 3.
- Headless Chromium: modal renders with per-type rows, `Totaal plaatsen 107`, `Fysieke vakken 105`; align toggle changes totals; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_