### PR TITLE
ParkPlanner: remove TestFit-kloon subtitle

### DIFF
--- a/files/testfit/index.html
+++ b/files/testfit/index.html
@@ -6,8 +6,8 @@
   <meta name="theme-color" content="#0f1216" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-  <title>ParkPlanner — TestFit-kloon</title>
-  <meta name="description" content="Automatische parkeerplanner: teken een site op OSM- of satellietkaarten, genereer live parkeervakken, rijstroken en metrics. Een open-source TestFit-kloon in React." />
+  <title>ParkPlanner</title>
+  <meta name="description" content="Automatische parkeerplanner: teken een site op OSM- of satellietkaarten, genereer live parkeervakken, rijstroken en metrics." />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🅿️</text></svg>" />
   <link rel="stylesheet" href="./styles.css" />
   <!-- Vendored dependencies as classic UMD scripts (globals). No import

--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -1463,7 +1463,7 @@ function App() {
   return html`
     <div className="app">
       <div className="toolbar">
-        <div className="brand"><span className="logo">🅿️</span><span>ParkPlanner<br/><small>TestFit-kloon</small></span></div>
+        <div className="brand"><span className="logo">🅿️</span><span>ParkPlanner</span></div>
         <div className="tb-sep"></div>
         ${toolBtn('select', 'Selecteer', 'V', tool, setTool, setDrawing)}
         ${toolBtn('site', 'Site', 'P', tool, setTool, setDrawing)}


### PR DESCRIPTION
## Summary

Removes the "TestFit-kloon" subtitle shown under the ParkPlanner brand in the toolbar, and drops the same tagline from the page `<title>` and meta description.

## Changes
- `files/testfit/src/app.js` — brand block now shows only "ParkPlanner".
- `files/testfit/index.html` — title/meta cleaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_