### PR TITLE
ParkPlanner: landscape islands (TestFit Max stall run)

### DIFF
--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -29,6 +29,7 @@ const PRESETS = {
 const DEFAULT_PARAMS = {
   stallWidth: 2.7, stallDepth: 5.5, aisleWidth: 7.3,
   angle: 90, setback: 6, padding: 0.6, maxRun: 12,
+  islandWidth: 0, // width (m) of landscape islands inserted every maxRun stalls (0 = off)
   compactRatio: 0, evRatio: 0.05, ada: true,
   singleLoaded: false, deadEndTurnaround: false, turnaround: 7,
   buildingGLA: 0, parkingRatio: 0, // GLA (m²) + stalls per 100 m² (zoning)
@@ -173,6 +174,18 @@ function draw(ctx, opts) {
       ctx.lineWidth = 1.2;
       ctx.stroke();
       ctx.setLineDash([]);
+    }
+  }
+
+  // Landscape islands (green planters that break up long rows)
+  if (layers.parking && result.islands) {
+    for (const is of result.islands) {
+      pathPoly(ctx, is, w2s, true);
+      ctx.fillStyle = 'rgba(63,155,70,0.55)';
+      ctx.fill();
+      ctx.strokeStyle = 'rgba(34,110,40,0.8)';
+      ctx.lineWidth = 1;
+      ctx.stroke();
     }
   }
 
@@ -611,6 +624,7 @@ function draw25D(ctx, opts) {
   if (site.length >= 3) { path(site, 0); ctx.fillStyle = '#12161c'; ctx.fill(); ctx.strokeStyle = '#f8b500'; ctx.lineWidth = 2; ctx.stroke(); }
   (doc.annotations || []).filter((a) => a.kind === 'grass' && a.points.length >= 3).forEach((a) => { path(a.points, 0); ctx.fillStyle = hexA('#3f9b46', 0.5); ctx.fill(); });
   (result.aisles || []).forEach((a) => { path(a.poly, 0); ctx.fillStyle = '#2b3340'; ctx.fill(); });
+  (result.islands || []).forEach((is) => { path(is, 0.2); ctx.fillStyle = hexA('#3f9b46', 0.7); ctx.fill(); });
   (result.stalls || []).forEach((st) => {
     path(st.poly, 0);
     ctx.fillStyle = (STALL_TYPES[st.type] || STALL_TYPES.standard).color;
@@ -798,7 +812,7 @@ function App() {
       const o = ovAisles[key] || {};
       return { poly: q, key, oneway: !!o.oneway, dir: o.dir || 1, locked: !!lockA[key] };
     });
-    return { stalls, aisles, orientationCount: result.orientationCount };
+    return { stalls, aisles, islands: result.islands || [], orientationCount: result.orientationCount };
   }, [result, doc.overrides, doc.manualStalls]);
 
   const renderNow = useCallback(() => {
@@ -1744,6 +1758,7 @@ function App() {
           ${slider('Setback', 'setback', doc.params.setback, 0, 20, 0.5, 'm', setParam)}
           ${slider('Padding (buffer)', 'padding', doc.params.padding, 0, 3, 0.1, 'm', setParam)}
           ${slider('Max. rijlengte', 'maxRun', doc.params.maxRun, 0, 30, 1, 'vak', setParam)}
+          ${slider('Groeneilanden (breedte)', 'islandWidth', doc.params.islandWidth, 0, 6, 0.5, 'm', setParam, (v) => v > 0 ? `${(+v).toFixed(1)} m` : 'uit')}
           <div className="toggle">
             <span>Single-loaded reststroken</span>
             <input type="checkbox" checked=${!!doc.params.singleLoaded} onChange=${(e) => setParam('singleLoaded', e.target.checked)} />

--- a/files/testfit/src/solver.js
+++ b/files/testfit/src/solver.js
@@ -118,7 +118,7 @@ export function adaRequirement(totalStalls) {
  * (the "Row Axis change" cycle); defaults to the best.
  */
 export function solveParking(site, obstacles, params, orientationIndex = 0) {
-  const empty = { stalls: [], aisles: [], angleUsed: 0, orientationCount: 0 };
+  const empty = { stalls: [], aisles: [], islands: [], angleUsed: 0, orientationCount: 0 };
   const buildable = computeBuildable(site, params.setback);
   if (!buildable || polygonArea(buildable) < 1) return empty;
 
@@ -169,7 +169,7 @@ function packStripBest(buildable, blockers, params, orientationIndex = 0) {
   if (angleSet.length === 0) angleSet.push(0);
   const results = angleSet.map((theta) => packOrientation(buildable, blockers, params, theta));
   results.sort((a, b) => b.stalls.length - a.stalls.length);
-  const chosen = results[Math.min(orientationIndex, results.length - 1)] || { stalls: [], aisles: [], angleUsed: 0 };
+  const chosen = results[Math.min(orientationIndex, results.length - 1)] || { stalls: [], aisles: [], islands: [], angleUsed: 0 };
   return { ...chosen, orientationCount: results.length };
 }
 
@@ -250,7 +250,7 @@ function packConcentric(buildable, blockers, params) {
     if (outer.length || inner.length) for (const q of aq) aisles.push(q);
   }
   assignStallTypes(stalls, params);
-  return { stalls, aisles, angleUsed: 0 };
+  return { stalls, aisles, islands: [], angleUsed: 0 };
 }
 
 /**
@@ -279,8 +279,10 @@ function packHybrid(buildable, blockers, params) {
   for (const a of strip.aisles) {
     if (distPointToPolygonBoundary(polygonCentroid(a), buildable) > d) aisles.push(a);
   }
+  // Straight interior can carry landscape islands.
+  const islands = strip.islands ? strip.islands.filter((is) => distPointToPolygonBoundary(polygonCentroid(is), buildable) > d) : [];
   assignStallTypes(stalls, params);
-  return { stalls, aisles, angleUsed: 0 };
+  return { stalls, aisles, islands, angleUsed: 0 };
 }
 
 /**
@@ -310,16 +312,31 @@ function packOrientation(buildable, blockers, params, theta) {
 
   const stalls = [];
   const aisles = [];
+  const islands = [];
   const maxRun = params.maxRun > 0 ? params.maxRun : Infinity;
+  const islandW = params.islandWidth > 0 ? params.islandWidth : 0;
   const singleLoaded = !!params.singleLoaded;
   const deadEnd = !!params.deadEndTurnaround;
   const turn = params.turnaround > 0 ? params.turnaround : 7;
+
+  // Landscape-island columns: after every `maxRun` stalls reserve a strip of
+  // width `islandW`. Positions are constant across modules so the green
+  // islands line up in columns (like TestFit's "Max stall run" planters).
+  let islandRanges = null;
+  if (islandW > 0 && isFinite(maxRun) && maxRun >= 1) {
+    islandRanges = [];
+    const period = maxRun * pitch + islandW;
+    for (let x = bb.minX + maxRun * pitch; x + islandW <= bb.maxX + 1e-6; x += period) islandRanges.push([x, x + islandW]);
+    if (islandRanges.length === 0) islandRanges = null;
+  }
+  const overlapsIsland = (x0, x1) => islandRanges && islandRanges.some(([a, b]) => x0 < b - 1e-6 && x1 > a + 1e-6);
 
   // Place one row of stalls; returns how many were placed.
   const placeRow = (y0, y1, dir, spans) => {
     let placed = 0, run = 0;
     for (let x = bb.minX; x + pitch <= bb.maxX + 1e-6; x += pitch) {
-      if (run >= maxRun) { run = 0; continue; }                 // planter gap
+      if (overlapsIsland(x, x + pitch)) { run = 0; continue; }   // landscape island
+      if (!islandRanges && run >= maxRun) { run = 0; continue; } // planter gap (no island strip)
       if (spans && !inAllowedSpan(x, x + pitch, spans, turn)) { run = 0; continue; } // turnaround
       const quad = stallQuad(x, y0, y1, pitch, shear, dir);
       if (!quadInsidePolygon(quad, local)) { run = 0; continue; }
@@ -332,25 +349,40 @@ function packOrientation(buildable, blockers, params, theta) {
   const pushAisle = (y0, y1) => aisles.push(
     [{ x: bb.minX, y: y0 }, { x: bb.maxX, y: y0 }, { x: bb.maxX, y: y1 }, { x: bb.minX, y: y1 }]
       .map((p) => rotatePoint(p, theta, pivot)));
+  // Emit landscape islands filling a single row band (only where inside the
+  // buildable area and clear of blockers).
+  const addIslandBand = (ry0, ry1) => {
+    if (!islandRanges) return;
+    for (const [a, b] of islandRanges) {
+      const c = { x: (a + b) / 2, y: (ry0 + ry1) / 2 };
+      if (!pointInPolygon(c, local)) continue;
+      if (localBlockers.some((bl) => pointInPolygon(c, bl))) continue;
+      islands.push([{ x: a, y: ry0 }, { x: b, y: ry0 }, { x: b, y: ry1 }, { x: a, y: ry1 }]
+        .map((p) => rotatePoint(p, theta, pivot)));
+    }
+  };
 
   // Double-loaded modules bottom-to-top.
   let yBase = bb.minY;
   for (; yBase + moduleH <= bb.maxY + 1e-6; yBase += moduleH) {
     const aisleY0 = yBase + rowDepth, aisleY1 = aisleY0 + aisle;
     const spans = deadEnd ? insideSpans(local, (aisleY0 + aisleY1) / 2, bb.minX, bb.maxX, Math.min(pitch, aisle)) : null;
-    const placed = placeRow(yBase, yBase + rowDepth, 1, spans) + placeRow(aisleY1, aisleY1 + rowDepth, -1, spans);
-    if (placed > 0) pushAisle(aisleY0, aisleY1);
+    const p1 = placeRow(yBase, yBase + rowDepth, 1, spans);
+    const p2 = placeRow(aisleY1, aisleY1 + rowDepth, -1, spans);
+    if (p1 + p2 > 0) pushAisle(aisleY0, aisleY1);
+    if (p1 > 0) addIslandBand(yBase, yBase + rowDepth);
+    if (p2 > 0) addIslandBand(aisleY1, aisleY1 + rowDepth);
   }
 
   // Single-loaded module (aisle + one row) in a shallow leftover band.
   if (singleLoaded && bb.maxY - yBase >= aisle + rowDepth - 1e-6) {
     const aisleY0 = yBase, aisleY1 = yBase + aisle;
     const spans = deadEnd ? insideSpans(local, (aisleY0 + aisleY1) / 2, bb.minX, bb.maxX, Math.min(pitch, aisle)) : null;
-    if (placeRow(aisleY1, aisleY1 + rowDepth, -1, spans) > 0) pushAisle(aisleY0, aisleY1);
+    if (placeRow(aisleY1, aisleY1 + rowDepth, -1, spans) > 0) { pushAisle(aisleY0, aisleY1); addIslandBand(aisleY1, aisleY1 + rowDepth); }
   }
 
   assignStallTypes(stalls, params);
-  return { stalls, aisles, angleUsed: theta };
+  return { stalls, aisles, islands, angleUsed: theta };
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds TestFit-style **landscape islands** that break up long parking rows, one of the features shown in the reference Parking Solver video.

- New **"Groeneilanden (breedte)"** slider (0–6 m). When > 0, the solver reserves a green landscape strip after every `Max. rijlengte` stalls. Island columns are positioned identically across rows so they line up.
- Islands render as green planters in both 2D and 2.5D. `0 m` keeps the previous behaviour (no islands).

## Changes
- `files/testfit/src/solver.js` — `packOrientation` computes island x-ranges, skips stalls that overlap them, and emits island polygons; threaded through `packStripBest`/`packHybrid`/`solveParking` (consistent `islands: []` shape).
- `files/testfit/src/app.js` — `islandWidth` default param, slider, island rendering in `draw()` and `draw25D()`, islands carried through the `deco` memo.

## Verification
- Node: default site 216 stalls / 0 islands with width 0; with `maxRun 8, islandWidth 2.5` → 192 stalls / 24 islands.
- Headless Chromium: enabling the slider drops the total (105 → 99) and renders green islands with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_