### PR TITLE
ParkPlanner: import parcel boundary from GeoJSON/KML

### DIFF
--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -10,8 +10,9 @@ import {
   pointInPolygon, rectPoly, tessellateClosed,
 } from './geometry.js';
 import * as basemap from './basemap.js';
-import { BASEMAPS, geocode } from './basemap.js';
+import { BASEMAPS, geocode, latLonToLocal } from './basemap.js';
 import { toGeoJSON, toDXF, toCSV } from './exporters.js';
+import { parseParcel, simplifyRing } from './importers.js';
 
 const html = htm.bind(React.createElement);
 const ANGLE_SNAP = Math.PI / 12; // 15° increments for hold-to-align drawing
@@ -1398,6 +1399,33 @@ function App() {
     reader.readAsText(file);
     e.target.value = '';
   };
+  // Import a real parcel boundary from GeoJSON or KML: anchor the geo frame at
+  // the ring centroid, convert to local metres, simplify, and use it as the site.
+  const applyParcel = (ring) => {
+    const lat = ring.reduce((s, p) => s + p.lat, 0) / ring.length;
+    const lon = ring.reduce((s, p) => s + p.lon, 0) / ring.length;
+    const geo = { lat, lon };
+    let site = simplifyRing(ring.map((p) => latLonToLocal(p, geo)), 0.5, 120);
+    if (site.length < 3) { alert('Geen bruikbare perceelgrens gevonden.'); return; }
+    dispatch({ type: 'RESET', doc: { ...initialDoc, site, geo, obstacles: [] } });
+    setBasemapStyle('satellite');
+    fittedRef.current = true;
+    const fv = fitView(site, sizeRef.current.w, sizeRef.current.h);
+    if (fv) setView(fv);
+    setOnboardOpen(false);
+  };
+  const importParcel = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const ring = parseParcel(reader.result, file.name);
+      if (!ring || ring.length < 3) { alert('Geen perceelgrens gevonden in dit bestand (GeoJSON of KML verwacht).'); return; }
+      applyParcel(ring);
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+  };
   const exportPNG = () => {
     canvasRef.current.toBlob((blob) => downloadBlob(blob, 'parkplanner.png'));
   };
@@ -1502,6 +1530,7 @@ function App() {
         <button className="btn ghost" onClick=${fitToSite}>⤢ Fit</button>
         <button className="btn ghost" onClick=${saveJSON}>Opslaan</button>
         <label className="btn ghost">Laden<input type="file" accept="application/json" onChange=${loadJSON} style=${{ display: 'none' }} /></label>
+        <label className="btn ghost" title="Perceelgrens importeren (GeoJSON of KML)">Perceel<input type="file" accept=".geojson,.json,.kml,application/geo+json,application/vnd.google-earth.kml+xml" onChange=${importParcel} style=${{ display: 'none' }} /></label>
         <div className="dropdown">
           <button className="btn ghost" onClick=${() => setExportOpen((o) => !o)}>Export ▾</button>
           ${exportOpen && html`
@@ -1871,6 +1900,12 @@ function App() {
                 <div className="oc-t">Project laden</div>
                 <div className="oc-d">Open een eerder opgeslagen .json — locatie en camera worden hersteld.</div>
                 <input type="file" accept="application/json" onChange=${loadJSON} style=${{ display: 'none' }} />
+              </label>
+              <label className="onboard-card">
+                <div className="oc-ico">🗺️</div>
+                <div className="oc-t">Perceel importeren</div>
+                <div className="oc-d">Laad een echte perceelgrens uit GeoJSON of KML en plan erop.</div>
+                <input type="file" accept=".geojson,.json,.kml,application/geo+json,application/vnd.google-earth.kml+xml" onChange=${importParcel} style=${{ display: 'none' }} />
               </label>
             </div>
 

--- a/files/testfit/src/importers.js
+++ b/files/testfit/src/importers.js
@@ -1,0 +1,117 @@
+// ============================================================
+// importers.js — read a parcel boundary from GeoJSON or KML.
+// Returns the outer ring of the largest polygon as [{lat, lon}, …],
+// or null when nothing usable is found.
+// ============================================================
+
+// Shoelace area in lon/lat units — only used to compare candidate rings.
+function ringArea(ring) {
+  let a = 0;
+  for (let i = 0, n = ring.length; i < n; i++) {
+    const p = ring[i], q = ring[(i + 1) % n];
+    a += p.lon * q.lat - q.lon * p.lat;
+  }
+  return Math.abs(a) / 2;
+}
+
+// Drop a duplicated closing vertex if the ring repeats its first point.
+function dropClosing(ring) {
+  if (ring.length > 1) {
+    const a = ring[0], b = ring[ring.length - 1];
+    if (Math.abs(a.lat - b.lat) < 1e-9 && Math.abs(a.lon - b.lon) < 1e-9) return ring.slice(0, -1);
+  }
+  return ring;
+}
+
+// ---- GeoJSON ----
+function collectPolygons(geom, out) {
+  if (!geom) return;
+  if (geom.type === 'Polygon') out.push(geom.coordinates[0]);
+  else if (geom.type === 'MultiPolygon') geom.coordinates.forEach((poly) => out.push(poly[0]));
+  else if (geom.type === 'GeometryCollection') (geom.geometries || []).forEach((g) => collectPolygons(g, out));
+}
+
+function parseGeoJSON(obj) {
+  const rings = [];
+  if (obj.type === 'FeatureCollection') (obj.features || []).forEach((f) => collectPolygons(f.geometry, rings));
+  else if (obj.type === 'Feature') collectPolygons(obj.geometry, rings);
+  else collectPolygons(obj, rings);
+  const asLL = rings
+    .map((r) => dropClosing((r || []).map((c) => ({ lon: +c[0], lat: +c[1] }))))
+    .filter((r) => r.length >= 3 && r.every((p) => isFinite(p.lat) && isFinite(p.lon)));
+  if (!asLL.length) return null;
+  asLL.sort((a, b) => ringArea(b) - ringArea(a));
+  return asLL[0];
+}
+
+// ---- KML ----
+function parseCoordString(text) {
+  return text.trim().split(/\s+/).map((tok) => {
+    const [lon, lat] = tok.split(',');
+    return { lon: +lon, lat: +lat };
+  }).filter((p) => isFinite(p.lat) && isFinite(p.lon));
+}
+
+function parseKML(text) {
+  let rings = [];
+  if (typeof DOMParser !== 'undefined') {
+    try {
+      const doc = new DOMParser().parseFromString(text, 'text/xml');
+      // Prefer outer boundaries; fall back to any <coordinates>.
+      let nodes = [...doc.getElementsByTagName('outerBoundaryIs')]
+        .map((n) => n.getElementsByTagName('coordinates')[0]).filter(Boolean);
+      if (!nodes.length) nodes = [...doc.getElementsByTagName('coordinates')];
+      rings = nodes.map((n) => dropClosing(parseCoordString(n.textContent || '')));
+    } catch (e) { rings = []; }
+  }
+  if (!rings.length) {
+    // Regex fallback when there's no DOMParser.
+    const m = text.match(/<coordinates>([\s\S]*?)<\/coordinates>/gi) || [];
+    rings = m.map((block) => dropClosing(parseCoordString(block.replace(/<\/?coordinates>/gi, ''))));
+  }
+  rings = rings.filter((r) => r.length >= 3);
+  if (!rings.length) return null;
+  rings.sort((a, b) => ringArea(b) - ringArea(a));
+  return rings[0];
+}
+
+export function parseParcel(text, name = '') {
+  const lname = (name || '').toLowerCase();
+  const looksKml = lname.endsWith('.kml') || /<kml[\s>]/i.test(text) || (/<coordinates>/i.test(text) && !text.trim().startsWith('{'));
+  if (!looksKml) {
+    try { return parseGeoJSON(JSON.parse(text)); } catch (e) { /* try KML */ }
+  }
+  return parseKML(text);
+}
+
+// ---- Douglas–Peucker simplification (points in metres) ----
+function dpSimplify(pts, tol) {
+  if (pts.length <= 3) return pts;
+  const keep = new Array(pts.length).fill(false);
+  keep[0] = keep[pts.length - 1] = true;
+  const stack = [[0, pts.length - 1]];
+  while (stack.length) {
+    const [s, e] = stack.pop();
+    let maxD = 0, idx = -1;
+    const a = pts[s], b = pts[e];
+    const dx = b.x - a.x, dy = b.y - a.y, len = Math.hypot(dx, dy) || 1;
+    for (let i = s + 1; i < e; i++) {
+      const d = Math.abs((pts[i].x - a.x) * dy - (pts[i].y - a.y) * dx) / len;
+      if (d > maxD) { maxD = d; idx = i; }
+    }
+    if (maxD > tol && idx > 0) { keep[idx] = true; stack.push([s, idx], [idx, e]); }
+  }
+  return pts.filter((_, i) => keep[i]);
+}
+
+// Simplify a closed metric ring, then hard-cap the vertex count.
+export function simplifyRing(pts, tol = 0.5, cap = 120) {
+  let out = dpSimplify(pts, tol);
+  if (out.length > cap) {
+    const step = out.length / cap;
+    const dec = [];
+    for (let i = 0; i < out.length; i += step) dec.push(out[Math.floor(i)]);
+    out = dec;
+  }
+  return out;
+}

--- a/files/testfit/styles.css
+++ b/files/testfit/styles.css
@@ -446,7 +446,7 @@ select.preset {
 }
 .onboard-sub { color: var(--muted); font-size: 12.5px; line-height: 1.45; max-width: 460px; }
 .onboard-grid {
-  display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 16px;
+  display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; margin-bottom: 16px;
 }
 .onboard-card {
   display: flex; flex-direction: column; gap: 4px; text-align: left;


### PR DESCRIPTION
## Summary

Adds **parcel import** — plan on a real property line instead of drawing it by hand (TestFit's "Site Creation from Parcel").

- New `src/importers.js` extracts the outer ring of the largest polygon from **GeoJSON** (Feature / FeatureCollection / Geometry / MultiPolygon) or **KML** (`outerBoundaryIs` / `coordinates`), with a `DOMParser` path plus a regex fallback.
- Import anchors the geo frame at the ring centroid, converts lon/lat → local metres, simplifies the ring (Douglas–Peucker + 120-vertex cap), sets it as the site, switches to the satellite basemap and fits the camera.
- Reachable from the **onboarding** screen ("Perceel importeren" card) and a new toolbar **"Perceel"** button.

## Changes
- `files/testfit/src/importers.js` — new parser + `simplifyRing`.
- `files/testfit/src/app.js` — `importParcel`/`applyParcel`, onboarding card, toolbar button; imports `latLonToLocal`.
- `files/testfit/styles.css` — onboarding grid now 2×2 to fit the fourth card.

## Verification
- Node: GeoJSON and KML samples both parse to a 4-point ring.
- Headless Chromium: importing a KML parcel dismisses onboarding, anchors geo at `52.37035, 4.87075`, enables satellite, and generates 169 stalls on the imported boundary — no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_