### PR TITLE
ParkPlanner: custom stalls table (share per parking type)

### DIFF
--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -33,6 +33,7 @@ const DEFAULT_PARAMS = {
   angle: 90, setback: 6, padding: 0.6, maxRun: 12,
   islandWidth: 0, // width (m) of landscape islands inserted every maxRun stalls (0 = off)
   compactRatio: 0, evRatio: 0.05, ada: true,
+  mix: { compact: 0, ev: 0.05, staff: 0, visitor: 0, reserved: 0 }, // target share per type
   singleLoaded: false, deadEndTurnaround: false, turnaround: 7,
   buildingGLA: 0, parkingRatio: 0, // GLA (m²) + stalls per 100 m² (zoning)
   layout: 'strip', // 'strip' (straight rows) | 'perimeter' (follows the curve)
@@ -923,6 +924,10 @@ function App() {
   // ---------- Param helpers ----------
   const setParam = (key, value, commit = true) =>
     dispatch({ type: commit ? 'COMMIT' : 'LIVE', updater: (d) => ({ ...d, params: { ...d.params, [key]: value } }) });
+  const setMix = (key, value) => dispatch({ type: 'COMMIT', updater: (d) => {
+    const cur = d.params.mix || { compact: d.params.compactRatio || 0, ev: d.params.evRatio || 0, staff: 0, visitor: 0, reserved: 0 };
+    return { ...d, params: { ...d.params, mix: { ...cur, [key]: value } } };
+  } });
 
   const applyPreset = (key) => {
     const p = PRESETS[key];
@@ -2001,13 +2006,46 @@ function App() {
         </div>
 
         <div className="section">
-          <h3>Vaktypes-mix</h3>
-          ${slider('Compact', 'compactRatio', doc.params.compactRatio, 0, 0.5, 0.05, '', setParam, (v) => `${Math.round(v * 100)}%`)}
-          ${slider('EV', 'evRatio', doc.params.evRatio, 0, 0.5, 0.05, '', setParam, (v) => `${Math.round(v * 100)}%`)}
-          <div className="toggle">
-            <span>ADA-vakken (auto-tabel)</span>
-            <input type="checkbox" checked=${doc.params.ada} onChange=${(e) => setParam('ada', e.target.checked)} />
-          </div>
+          <h3>Vaktypes (mix)</h3>
+          ${(() => {
+            const keys = ['compact', 'ev', 'staff', 'visitor', 'reserved'];
+            const mix = doc.params.mix || { compact: doc.params.compactRatio || 0, ev: doc.params.evRatio || 0 };
+            const sum = keys.reduce((s, k) => s + (mix[k] || 0), 0);
+            return html`
+              <table className="mix-table">
+                <thead><tr><th>Type</th><th>Aandeel</th><th>Aantal</th></tr></thead>
+                <tbody>
+                  <tr>
+                    <td><span className="dot" style=${{ background: STALL_TYPES.standard.color }}></span>Standaard</td>
+                    <td className="mix-rem">${Math.max(0, Math.round((1 - sum) * 100))}%</td>
+                    <td>${metrics.counts.standard || 0}</td>
+                  </tr>
+                  ${keys.map((k) => html`
+                    <tr key=${k}>
+                      <td><span className="dot" style=${{ background: STALL_TYPES[k].color }}></span>${STALL_TYPES[k].label}</td>
+                      <td><input className="mix-in" type="number" min="0" max="100" step="5" value=${Math.round((mix[k] || 0) * 100)}
+                        onChange=${(e) => setMix(k, Math.max(0, Math.min(100, parseInt(e.target.value, 10) || 0)) / 100)} />%</td>
+                      <td>${metrics.counts[k] || 0}</td>
+                    </tr>`)}
+                  <tr>
+                    <td><span className="dot" style=${{ background: STALL_TYPES.ada.color }}></span>Minder-valide</td>
+                    <td>auto</td>
+                    <td>${metrics.counts.ada || 0}</td>
+                  </tr>
+                  <tr>
+                    <td><span className="dot" style=${{ background: STALL_TYPES.motorcycle.color }}></span>Motor</td>
+                    <td>handmatig</td>
+                    <td>${metrics.counts.motorcycle || 0}</td>
+                  </tr>
+                </tbody>
+              </table>
+              ${sum > 1 ? html`<div className="mix-warn">Totaal ${Math.round(sum * 100)}% &gt; 100% — er blijft geen standaard over.</div>` : ''}
+              <div className="toggle">
+                <span>Minder-valide (ADA) automatisch</span>
+                <input type="checkbox" checked=${doc.params.ada} onChange=${(e) => setParam('ada', e.target.checked)} />
+              </div>
+              <div className="mix-note">Motor markeer je handmatig op een vak (telt als 3 plaatsen).</div>`;
+          })()}
         </div>
 
         <div className="section">

--- a/files/testfit/src/solver.js
+++ b/files/testfit/src/solver.js
@@ -416,21 +416,30 @@ function stallQuad(x, y0, y1, pitch, shear, dir) {
 function assignStallTypes(stalls, params) {
   const n = stalls.length;
   if (n === 0) return;
-  const compactRatio = params.compactRatio || 0;
-  const evRatio = params.evRatio || 0;
+  // Target mix: a table of type → share of total. Falls back to the legacy
+  // compactRatio/evRatio params when no table is supplied (older saves).
+  const mix = params.mix || { compact: params.compactRatio || 0, ev: params.evRatio || 0 };
+  const order = ['ev', 'compact', 'staff', 'visitor', 'reserved']; // assignment priority
 
-  // Deterministic spread so the mix is visually even.
-  const compactEvery = compactRatio > 0 ? Math.round(1 / compactRatio) : 0;
-  const evEvery = evRatio > 0 ? Math.round(1 / evRatio) : 0;
-  stalls.forEach((st, i) => {
-    if (evEvery && i % evEvery === evEvery - 1) st.type = 'ev';
-    else if (compactEvery && i % compactEvery === 0) st.type = 'compact';
-    else st.type = 'standard';
-  });
+  for (const st of stalls) st.type = 'standard';
+  const taken = new Array(n).fill(false);
+  for (const key of order) {
+    const r = mix[key] || 0;
+    if (r <= 0 || !STALL_TYPES[key]) continue;
+    const count = Math.min(n, Math.round(r * n));
+    if (count <= 0) continue;
+    const stride = n / count;
+    for (let k = 0; k < count; k++) {
+      let idx = Math.round(k * stride) % n, guard = 0;
+      while (taken[idx] && guard < n) { idx = (idx + 1) % n; guard++; }
+      if (guard >= n) break;
+      taken[idx] = true; stalls[idx].type = key;
+    }
+  }
 
   if (params.ada) {
     const { required } = adaRequirement(n);
-    // Mark the first `required` stalls as ADA (kept near the front row).
+    // ADA spaces sit nearest the front (first stalls), overriding the mix.
     for (let i = 0; i < Math.min(required, n); i++) stalls[i].type = 'ada';
   }
 }

--- a/files/testfit/styles.css
+++ b/files/testfit/styles.css
@@ -483,3 +483,20 @@ select.preset {
 .scheme-label { font-size: 12px; font-weight: 600; }
 .scheme-count { font-size: 11px; color: var(--muted); }
 .scheme-row .btn { padding: 4px 8px; font-size: 11px; }
+
+/* ---- Vaktypes mix table ---- */
+.mix-table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 8px; }
+.mix-table th {
+  text-align: left; color: var(--muted); font-weight: 500; font-size: 10.5px;
+  text-transform: uppercase; letter-spacing: 0.05em; padding: 2px 4px; border-bottom: 1px solid var(--border);
+}
+.mix-table th:last-child, .mix-table td:last-child { text-align: right; }
+.mix-table td { padding: 4px; border-bottom: 1px solid rgba(42,49,59,0.5); vertical-align: middle; }
+.mix-table td .dot { width: 10px; height: 10px; border-radius: 3px; display: inline-block; margin-right: 6px; vertical-align: middle; }
+.mix-table .mix-rem { color: var(--muted); }
+.mix-in {
+  width: 46px; background: var(--panel-2); border: 1px solid var(--border); color: var(--text);
+  border-radius: 4px; padding: 2px 4px; font-size: 12px; text-align: right; margin-right: 2px;
+}
+.mix-warn { color: var(--danger); font-size: 11px; margin: 2px 0 8px; }
+.mix-note { color: var(--muted); font-size: 11px; margin-top: 8px; line-height: 1.4; }


### PR DESCRIPTION
## Summary

TestFit's **Custom Stalls** panel: instead of two fixed sliders, a **Vaktypes (mix) table** lets you set the target share per parking type and see the resulting count live.

- Editable percentages for **Compact, EV, Personeel, Bezoeker, Gereserveerd**; the remainder becomes **Standaard**. Minder-valide (ADA) stays automatic by code, Motor stays a manual mark (counts as 3).
- The solver allocates types from a `params.mix` table (evenly spread across the lot). Legacy `compactRatio`/`evRatio` saves keep working via a fallback.

## Changes
- `files/testfit/src/solver.js` — `assignStallTypes` rewritten to be `mix`-table driven with legacy fallback.
- `files/testfit/src/app.js` — `mix` default, `setMix`, the mix table UI (with an over-100% warning), ADA toggle.
- `files/testfit/styles.css` — mix-table styling.

## Verification
- Node: mix `{compact 10%, ev 5%, staff 5%, reserved 2%}` on 216 stalls → compact 21, ev 10, staff 10, reserved 3, ada 7, standard 165; legacy fallback still yields compact/EV.
- Headless Chromium: setting Personeel to 15% drops Standaard 95%→80% and distributes orange "P" stalls; counts update live; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_