### PR TITLE
ParkPlanner: TestFit-style deal tabulation bar

### DIFF
--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -817,6 +817,7 @@ function App() {
   const [onboardOpen, setOnboardOpen] = useState(true);   // welcome overlay on open
   const [schemes, setSchemes] = useState(null);           // generated layout variants
   const [optState, setOptState] = useState(null);         // { running, i, n } | { done, label, before, after }
+  const [dealbarOpen, setDealbarOpen] = useState(true);   // bottom deal-tabulation bar
 
   const wrapRef = useRef(null);
   const canvasRef = useRef(null);
@@ -1957,7 +1958,7 @@ function App() {
           style=${{ cursor: tool === 'pan' ? 'grab' : tool === 'select' ? 'default' : 'crosshair' }} />
         ${viewMode === '2d' && hintText && html`<div className="hint">${hintText}</div>`}
         ${viewMode === '2.5d' && html`<div className="hint">2.5D-weergave · alleen-lezen — schakel naar 2D om te bewerken</div>`}
-        <div className="hud">
+        <div className="hud" style=${{ bottom: (dealbarOpen && viewMode !== '3d' ? 96 : 12) + 'px' }}>
           <span><b>${metrics.total}</b> vakken</span>
           <span>·</span>
           <span>schaal <b>${view.scale.toFixed(1)}</b> px/m</span>
@@ -1965,7 +1966,48 @@ function App() {
           <span>${solving ? 'rekenen…' : 'live'}</span>
         </div>
         ${basemapStyle !== 'none' && viewMode === '2d' && BASEMAPS[basemapStyle].attribution && html`
-          <div className="attrib">${BASEMAPS[basemapStyle].attribution}</div>`}
+          <div className="attrib" style=${{ bottom: (dealbarOpen ? 96 : 6) + 'px' }}>${BASEMAPS[basemapStyle].attribution}</div>`}
+
+        ${viewMode !== '3d' && html`
+          <div className=${'dealbar' + (dealbarOpen ? '' : ' closed')}>
+            <button className="dealbar-toggle" onClick=${() => setDealbarOpen((o) => !o)}>${dealbarOpen ? '▾' : '▴'} Tabulatie</button>
+            ${dealbarOpen && html`
+              <div className="dealbar-cols">
+                <div className="deal-col">
+                  <div className="deal-h">Site</div>
+                  <div className="deal-row"><span>Oppervlak</span><b>${fmt(metrics.siteArea)} m²</b></div>
+                  <div className="deal-row"><span>Bebouwd</span><b>${(metrics.coverage * 100).toFixed(0)}%</b></div>
+                  <div className="deal-row"><span>Verhard</span><b>${(metrics.imperviousPct * 100).toFixed(0)}%</b></div>
+                  <div className="deal-row"><span>FAR</span><b>${metrics.far.toFixed(2)}</b></div>
+                </div>
+                <div className="deal-col">
+                  <div className="deal-h">Gebouw</div>
+                  <div className="deal-row"><span>Voetafdruk</span><b>${fmt(metrics.buildingArea)} m²</b></div>
+                  <div className="deal-row"><span>Vloeropp. (GLA)</span><b>${fmt(metrics.grossFloorArea)} m²</b></div>
+                  <div className="deal-row"><span>Beschikbaar</span><b>${fmt(metrics.buildableArea)} m²</b></div>
+                </div>
+                <div className="deal-col">
+                  <div className="deal-h">Parking</div>
+                  <div className="deal-row"><span>Plaatsen</span><b>${metrics.total}</b></div>
+                  <div className="deal-row"><span>Fysieke vakken</span><b>${metrics.physicalStalls}</b></div>
+                  <div className="deal-row"><span>m² / vak</span><b>${metrics.areaPerStall ? metrics.areaPerStall.toFixed(1) : '—'}</b></div>
+                  <div className="deal-row"><span>Rijstroken</span><b>${metrics.aisleCount}</b></div>
+                </div>
+                <div className="deal-col">
+                  <div className="deal-h">Toegankelijk</div>
+                  <div className="deal-row"><span>Minder-valide</span><b>${metrics.adaProvided}/${metrics.adaRequired}</b></div>
+                  <div className="deal-row"><span>Toegangspunten</span><b>${metrics.accessCount}</b></div>
+                  <div className="deal-row"><span>Oriëntaties</span><b>${metrics.orientationCount}</b></div>
+                </div>
+                ${metrics.requiredStalls != null && html`
+                <div className="deal-col">
+                  <div className="deal-h">Zoning</div>
+                  <div className="deal-row"><span>Vereist</span><b>${metrics.requiredStalls}</b></div>
+                  <div className="deal-row"><span>Geleverd</span><b>${metrics.total}</b></div>
+                  <div className="deal-row"><span>Saldo</span><b className=${metrics.total >= metrics.requiredStalls ? 'ok' : 'bad'}>${metrics.total - metrics.requiredStalls >= 0 ? '+' : ''}${metrics.total - metrics.requiredStalls}</b></div>
+                </div>`}
+              </div>`}
+          </div>`}
 
         ${viewMode === '3d' && html`
           <div id="pp-map3d" className="map3d"></div>

--- a/files/testfit/styles.css
+++ b/files/testfit/styles.css
@@ -507,3 +507,31 @@ select.preset {
   background: #16241a; border: 1px solid var(--accent-2); border-radius: 6px; color: var(--text);
 }
 .opt-result .opt-up { color: var(--accent-2); font-weight: 600; }
+
+/* ---- Deal tabulation bar (TestFit-style bottom strip) ---- */
+.dealbar { position: absolute; left: 0; right: 0; bottom: 0; z-index: 8; }
+.dealbar:not(.closed) {
+  background: rgba(15, 18, 22, 0.94);
+  border-top: 1px solid var(--border);
+  backdrop-filter: blur(4px);
+}
+.dealbar-toggle {
+  position: absolute; right: 12px; top: -23px; height: 23px;
+  background: rgba(15, 18, 22, 0.94); border: 1px solid var(--border); border-bottom: none;
+  color: var(--muted); font-size: 11px; padding: 0 12px; border-radius: 6px 6px 0 0;
+  cursor: pointer; letter-spacing: 0.04em; text-transform: uppercase;
+}
+.dealbar-toggle:hover { color: var(--text); }
+.dealbar-cols { display: flex; overflow-x: auto; padding: 9px 14px; gap: 0; }
+.deal-col { min-width: 148px; padding: 0 18px; border-right: 1px solid var(--border); flex: 0 0 auto; }
+.deal-col:first-child { padding-left: 0; }
+.deal-col:last-child { border-right: none; }
+.deal-h {
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.09em;
+  color: var(--accent); margin-bottom: 6px; font-weight: 700;
+}
+.deal-row { display: flex; justify-content: space-between; gap: 16px; font-size: 12px; padding: 1.5px 0; }
+.deal-row span { color: var(--muted); white-space: nowrap; }
+.deal-row b { font-variant-numeric: tabular-nums; white-space: nowrap; }
+.deal-row b.ok { color: var(--accent-2); }
+.deal-row b.bad { color: var(--danger); }


### PR DESCRIPTION
## Summary

Partly recreates TestFit's UI: a **deal tabulation bar** across the bottom of the canvas.

- Collapsible bottom strip with grouped metric columns — **Site / Gebouw / Parking / Toegankelijk** (plus **Zoning** when a parking ratio is set) — styled like TestFit's tabulation row.
- Toggle via the **Tabulatie** tab; the HUD and basemap attribution shift up when it's open; hidden in 3D view.

## Changes
- `files/testfit/src/app.js` — `dealbarOpen` state + the dealbar JSX; HUD/attrib offset when open.
- `files/testfit/styles.css` — dealbar styling.

## Verification
- Headless Chromium: 4 metric columns render with correct values (Site 5.760 m², FAR 0.45, Parking 105, m²/vak 38.4, Minder-valide 5/5…); the Tabulatie tab collapses/expands it; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_