### PR TITLE
ParkPlanner: map-style toggle (Satelliet / Straten / Standaard / Geen)

### DIFF
--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -208,6 +208,13 @@ function makeTransform(view) {
   return { w2s, s2w };
 }
 
+// Mapbox style URLs per toggle option. 'none' → no map (dark planner backdrop).
+const MAP_STYLES = {
+  satellite: 'mapbox://styles/mapbox/satellite-streets-v12',
+  streets: 'mapbox://styles/mapbox/streets-v12',
+  standard: 'mapbox://styles/mapbox/standard',
+};
+
 // Translate our flat canvas camera (view) into a Mapbox {center, zoom} so the
 // basemap tracks it exactly in 2D. Web-mercator: mpp = 40075016.686·cos(lat)/(512·2^z).
 function mapCamFromView(view, size, geo) {
@@ -1010,6 +1017,7 @@ function App() {
   const [geoMsg, setGeoMsg] = useState('');
   const [viewMode, setViewMode] = useState('2d');            // '2d' (flat map) | '3d' (tilted map)
   const [mbToken, setMbToken] = useState(() => { try { return localStorage.getItem('pp_mapbox_token') || ''; } catch (e) { return ''; } });
+  const [mapStyle, setMapStyle] = useState(() => { try { return localStorage.getItem('pp_map_style') || 'satellite'; } catch (e) { return 'satellite'; } });
   const [mbTokenInput, setMbTokenInput] = useState('');
   const [map3dError, setMap3dError] = useState('');
   const [exportOpen, setExportOpen] = useState(false);
@@ -1167,7 +1175,7 @@ function App() {
     const dpr = Math.min(2, window.devicePixelRatio || 1);
     // 3D is rendered by the Mapbox map (the canvas overlay is hidden); the
     // canvas draws the editable plan only in 2D, transparently over the map.
-    if (viewMode === '3d') { ctx.clearRect(0, 0, canvas.width, canvas.height); }
+    if (viewMode === '3d' && map3dRef.current) { ctx.clearRect(0, 0, canvas.width, canvas.height); }
     else {
       draw(ctx, {
         view, doc, result: deco, layers, dpr,
@@ -1193,14 +1201,15 @@ function App() {
   // behind the canvas: flat in 2D (tracking our camera), tilted in 3D (with the
   // plan draped as GeoJSON layers).
   useEffect(() => {
-    if (!mbToken) { if (map3dRef.current) { map3dRef.current.destroy(); map3dRef.current = null; } return; }
+    // No token or style 'Geen' → no map; the plan renders on the dark backdrop.
+    if (!mbToken || mapStyle === 'none') { if (map3dRef.current) { map3dRef.current.destroy(); map3dRef.current = null; } return; }
     let cancelled = false;
     setMap3dError('');
     const container = document.getElementById('pp-map');
     if (!container) return;
     import('./map3d.js').then(async (m) => {
       if (cancelled) return;
-      const ctrl = await m.initMap(container, mbToken, doc.geo, buildPlan(), (msg) => setMap3dError(msg));
+      const ctrl = await m.initMap(container, mbToken, doc.geo, buildPlan(), (msg) => setMap3dError(msg), MAP_STYLES[mapStyle]);
       if (cancelled) { if (ctrl) ctrl.destroy(); return; }
       map3dRef.current = ctrl;
       ctrl.setMode(vmRef.current === '3d');
@@ -1209,7 +1218,7 @@ function App() {
     }).catch(() => setMap3dError('Mapbox kon niet laden.'));
     return () => { cancelled = true; if (map3dRef.current) { map3dRef.current.destroy(); map3dRef.current = null; } };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mbToken]);
+  }, [mbToken, mapStyle]);
 
   // Keep the flat basemap locked to our canvas camera in 2D.
   useEffect(() => {
@@ -2124,6 +2133,10 @@ function App() {
     try { localStorage.removeItem('pp_mapbox_token'); } catch (e) {}
     setMbToken(''); setMap3dError('');
   };
+  const changeMapStyle = (s) => {
+    try { localStorage.setItem('pp_map_style', s); } catch (e) {}
+    setMap3dError(''); setMapStyle(s);
+  };
 
   // ---------- Render UI ----------
   const hintText = {
@@ -2203,6 +2216,10 @@ function App() {
           <div className="geo-coord">📍 ${doc.geo.lat.toFixed(5)}, ${doc.geo.lon.toFixed(5)}</div>
           <div className="geo-coord" style=${{ marginTop: '6px' }}>
             ${mbToken ? html`🗺️ Kaart-token ✓ · <a href="#" onClick=${(e) => { e.preventDefault(); clearMbToken(); }} style=${{ color: 'var(--accent)' }}>wijzigen</a>` : '🗺️ Geen kaart-token'}
+          </div>
+          <div className="seg style-seg" style=${{ marginTop: '8px' }}>
+            ${[['satellite', 'Satelliet'], ['streets', 'Straten'], ['standard', 'Standaard'], ['none', 'Geen']].map(([s, lbl]) => html`
+              <button key=${s} className=${mapStyle === s ? 'active' : ''} onClick=${() => changeMapStyle(s)}>${lbl}</button>`)}
           </div>
           ${map3dError && html`<div className="geo-msg" style=${{ color: 'var(--danger)' }}>${map3dError}</div>`}
         </div>
@@ -2307,7 +2324,7 @@ function App() {
           <span>·</span>
           <span>${solving ? 'rekenen…' : 'live'}</span>
         </div>
-        ${mbToken && !map3dError && html`<div className="attrib" style=${{ bottom: (dealbarOpen ? 96 : 6) + 'px' }}>© Mapbox © OpenStreetMap</div>`}
+        ${mbToken && mapStyle !== 'none' && !map3dError && html`<div className="attrib" style=${{ bottom: (dealbarOpen ? 96 : 6) + 'px' }}>© Mapbox © OpenStreetMap</div>`}
 
         ${html`
           <div className=${'dealbar' + (dealbarOpen ? '' : ' closed')}>

--- a/files/testfit/src/map3d.js
+++ b/files/testfit/src/map3d.js
@@ -1,5 +1,5 @@
 // ============================================================
-// map3d.js — Mapbox GL basemap controller (Mapbox Standard style).
+// map3d.js — Mapbox GL basemap controller (style chosen by the caller).
 //
 // The whole planner sits on a live Mapbox map. In 2D the map is a flat
 // basemap that follows our canvas camera (the plan is drawn on the
@@ -12,9 +12,6 @@ import { STALL_TYPES } from './solver.js';
 import { polyOf } from './geometry.js';
 
 const MB_VERSION = 'v3.7.0';
-// Satellite + streets: robust, and ideal for planning on a real site. (The
-// newer 'mapbox/standard' style can render blank on some tokens.)
-const MAP_STYLE = 'mapbox://styles/mapbox/satellite-streets-v12';
 let mbPromise = null;
 
 function loadMapbox() {
@@ -105,15 +102,16 @@ function setData(map, plan, geo) {
  *   setMode(is3d)         — tilt + show/hide the draped plan layers
  *   setPlan(plan)         — refresh the plan GeoJSON
  */
-export async function initMap(container, token, geo, plan, onError) {
+export async function initMap(container, token, geo, plan, onError, styleUrl) {
   let mapboxgl;
   try { mapboxgl = await loadMapbox(); }
   catch (e) { onError('Mapbox GL kon niet laden — controleer je verbinding.'); return null; }
   mapboxgl.accessToken = token;
+  const style = styleUrl || 'mapbox://styles/mapbox/satellite-streets-v12';
   let map;
   try {
     map = new mapboxgl.Map({
-      container, style: MAP_STYLE,
+      container, style,
       center: [geo.lon, geo.lat], zoom: 17, pitch: 0, bearing: 0,
       interactive: false, antialias: true, attributionControl: false,
     });

--- a/files/testfit/styles.css
+++ b/files/testfit/styles.css
@@ -79,6 +79,9 @@ body {
 .seg.view-seg { width: auto; }
 .seg.view-seg button { flex: 0 0 auto; padding: 5px 10px; }
 
+.seg.style-seg { flex-wrap: wrap; }
+.seg.style-seg button { flex: 1 1 40%; padding: 5px 4px; font-size: 11.5px; }
+
 .dropdown { position: relative; }
 .dropdown .menu {
   position: absolute;


### PR DESCRIPTION
## Wat

Voegt een **kaart-stijl toggle** toe in het Locatie-paneel: **Satelliet / Straten / Standaard / Geen**. De kaart zat vast op één Mapbox-stijl; nu kies je zelf.

**"Geen"** schakelt de kaart volledig uit en tekent het plan op de donkere planner-achtergrond — een gegarandeerd-zichtbare fallback wanneer tiles geblokkeerd worden (bijv. door Brave Shields / een ad-blocker) of het token verkeerd geconfigureerd is.

## Wijzigingen

- **`src/map3d.js`** — `initMap` krijgt een `styleUrl`-parameter i.p.v. een hardgecodeerde stijl.
- **`src/app.js`** — `mapStyle`-state (bewaard in `localStorage` onder `pp_map_style`), `MAP_STYLES` url-map, map-lifecycle nu op `[mbToken, mapStyle]` (verwijdert/overslaat de kaart bij `'none'`), canvas tekent het plan óók in 3D wanneer er geen live kaart is, attributie alleen zichtbaar bij een actieve stijl.
- **`styles.css`** — wrappende `.style-seg` segmented control.

## Verificatie

- `node --check` op `app.js` + `map3d.js` → OK.
- Headless Chromium boot: toolbar/canvas/pp-map aanwezig, `.style-seg` toont `["Satelliet","Straten","Standaard","Geen"]`.
- Elke stijl aanklikken → wordt actief, bewaard in `localStorage`, geen relevante console-errors. (Mapbox-tiles renderen niet in de sandbox; de toggle-logica en "Geen"-fallback zijn wel geverifieerd.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_