### PR TITLE
ParkPlanner: fix silent map hang + add basemap diagnostics

### DIFF
--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -1020,6 +1020,9 @@ function App() {
   const [mapStyle, setMapStyle] = useState(() => { try { return localStorage.getItem('pp_map_style') || 'satellite'; } catch (e) { return 'satellite'; } });
   const [mbTokenInput, setMbTokenInput] = useState('');
   const [map3dError, setMap3dError] = useState('');
+  const [mapDiag, setMapDiag] = useState({});      // per-stage basemap status
+  const [diagOpen, setDiagOpen] = useState(false);
+  const [mapNonce, setMapNonce] = useState(0);     // bump to force a map retry
   const [exportOpen, setExportOpen] = useState(false);
   const [summaryOpen, setSummaryOpen] = useState(false);
   const [onboardOpen, setOnboardOpen] = useState(true);   // welcome overlay on open
@@ -1209,8 +1212,9 @@ function App() {
     if (!container) return;
     import('./map3d.js').then(async (m) => {
       if (cancelled) return;
-      const ctrl = await m.initMap(container, mbToken, doc.geo, buildPlan(), (msg) => setMap3dError(msg), MAP_STYLES[mapStyle]);
-      if (cancelled) { if (ctrl) ctrl.destroy(); return; }
+      const onDiag = (d) => setMapDiag((prev) => ({ ...prev, ...d }));
+      const ctrl = await m.initMap(container, mbToken, doc.geo, buildPlan(), (msg) => setMap3dError(msg), MAP_STYLES[mapStyle], onDiag);
+      if (cancelled || !ctrl) { if (ctrl) ctrl.destroy(); return; }
       map3dRef.current = ctrl;
       ctrl.setMode(vmRef.current === '3d');
       if (vmRef.current !== '3d') { const c = mapCamFromView(view, sizeRef.current, doc.geo); ctrl.follow2D(c.center, c.zoom); }
@@ -1218,7 +1222,7 @@ function App() {
     }).catch(() => setMap3dError('Mapbox kon niet laden.'));
     return () => { cancelled = true; if (map3dRef.current) { map3dRef.current.destroy(); map3dRef.current = null; } };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mbToken, mapStyle]);
+  }, [mbToken, mapStyle, mapNonce]);
 
   // Keep the flat basemap locked to our canvas camera in 2D.
   useEffect(() => {
@@ -2135,8 +2139,9 @@ function App() {
   };
   const changeMapStyle = (s) => {
     try { localStorage.setItem('pp_map_style', s); } catch (e) {}
-    setMap3dError(''); setMapStyle(s);
+    setMap3dError(''); setMapDiag({}); setMapStyle(s);
   };
+  const retryMap = () => { setMap3dError(''); setMapDiag({}); setMapNonce((n) => n + 1); };
 
   // ---------- Render UI ----------
   const hintText = {
@@ -2222,6 +2227,22 @@ function App() {
               <button key=${s} className=${mapStyle === s ? 'active' : ''} onClick=${() => changeMapStyle(s)}>${lbl}</button>`)}
           </div>
           ${map3dError && html`<div className="geo-msg" style=${{ color: 'var(--danger)' }}>${map3dError}</div>`}
+          ${mbToken && mapStyle !== 'none' && html`
+            <div className="geo-coord" style=${{ marginTop: '8px' }}>
+              <a href="#" onClick=${(e) => { e.preventDefault(); setDiagOpen(!diagOpen); }} style=${{ color: 'var(--accent)' }}>
+                ${diagOpen ? '▾' : '▸'} Kaart-diagnose
+              </a>
+              ${' · '}
+              <a href="#" onClick=${(e) => { e.preventDefault(); retryMap(); }} style=${{ color: 'var(--accent)' }}>opnieuw proberen</a>
+            </div>
+            ${diagOpen && html`
+              <div className="map-diag">
+                <div><span>WebGL</span><b>${mapDiag.webgl || '—'}</b></div>
+                <div><span>Bibliotheek</span><b>${mapDiag.lib || '—'}</b></div>
+                <div><span>Stijl</span><b>${mapDiag.style || '—'}</b></div>
+                <div><span>Tegels</span><b>${mapDiag.tiles == null ? '—' : mapDiag.tiles}</b></div>
+                ${mapDiag.detail && html`<div className="map-diag-detail">${mapDiag.detail}</div>`}
+              </div>`}`}
         </div>
         <div className="section">
           <h3>Teken (infrastructuur)</h3>

--- a/files/testfit/src/map3d.js
+++ b/files/testfit/src/map3d.js
@@ -12,23 +12,67 @@ import { STALL_TYPES } from './solver.js';
 import { polyOf } from './geometry.js';
 
 const MB_VERSION = 'v3.7.0';
+const MB_SEMVER = '3.7.0';
+// api.mapbox.com is on some ad-blocker filter lists; fall back to neutral CDNs
+// so a blocked library load doesn't kill the whole map.
+const MB_SOURCES = [
+  { js: `https://api.mapbox.com/mapbox-gl-js/${MB_VERSION}/mapbox-gl.js`, css: `https://api.mapbox.com/mapbox-gl-js/${MB_VERSION}/mapbox-gl.css`, name: 'api.mapbox.com' },
+  { js: `https://unpkg.com/mapbox-gl@${MB_SEMVER}/dist/mapbox-gl.js`, css: `https://unpkg.com/mapbox-gl@${MB_SEMVER}/dist/mapbox-gl.css`, name: 'unpkg.com' },
+  { js: `https://cdn.jsdelivr.net/npm/mapbox-gl@${MB_SEMVER}/dist/mapbox-gl.js`, css: `https://cdn.jsdelivr.net/npm/mapbox-gl@${MB_SEMVER}/dist/mapbox-gl.css`, name: 'jsdelivr.net' },
+];
+const LOAD_TIMEOUT_MS = 10000;
 let mbPromise = null;
 
-function loadMapbox() {
-  if (window.mapboxgl) return Promise.resolve(window.mapboxgl);
-  if (mbPromise) return mbPromise;
-  mbPromise = new Promise((resolve, reject) => {
-    const css = document.createElement('link');
-    css.rel = 'stylesheet';
-    css.href = `https://api.mapbox.com/mapbox-gl-js/${MB_VERSION}/mapbox-gl.css`;
-    document.head.appendChild(css);
+export function webglOk() {
+  try {
+    const c = document.createElement('canvas');
+    return !!(c.getContext('webgl2') || c.getContext('webgl') || c.getContext('experimental-webgl'));
+  } catch (e) { return false; }
+}
+
+// A <script> that is silently swallowed (blocker/extension/proxy) fires neither
+// onload nor onerror — without this timeout the whole init hangs with no signal.
+function loadScript(src) {
+  return new Promise((resolve, reject) => {
     const s = document.createElement('script');
-    s.src = `https://api.mapbox.com/mapbox-gl-js/${MB_VERSION}/mapbox-gl.js`;
-    s.async = true;
-    s.onload = () => (window.mapboxgl ? resolve(window.mapboxgl) : reject(new Error('mapboxgl ontbreekt')));
-    s.onerror = () => reject(new Error('Mapbox GL kon niet laden'));
+    let settled = false;
+    const finish = (fn, arg) => { if (settled) return; settled = true; clearTimeout(timer); fn(arg); };
+    const timer = setTimeout(() => { try { s.remove(); } catch (e) {} finish(reject, new Error('time-out (geen antwoord)')); }, LOAD_TIMEOUT_MS);
+    s.src = src; s.async = true;
+    s.onload = () => (window.mapboxgl ? finish(resolve, window.mapboxgl) : finish(reject, new Error('script geladen maar mapboxgl ontbreekt')));
+    s.onerror = () => { try { s.remove(); } catch (e) {} finish(reject, new Error('geblokkeerd of onbereikbaar')); };
     document.head.appendChild(s);
   });
+}
+
+function loadCss(href) {
+  try {
+    const css = document.createElement('link');
+    css.rel = 'stylesheet'; css.href = href;
+    document.head.appendChild(css);
+  } catch (e) {}
+}
+
+function loadMapbox(diag) {
+  if (window.mapboxgl) return Promise.resolve(window.mapboxgl);
+  if (mbPromise) return mbPromise;
+  mbPromise = (async () => {
+    const tried = [];
+    for (const src of MB_SOURCES) {
+      try {
+        diag({ lib: 'laden via ' + src.name + '…' });
+        const gl = await loadScript(src.js);
+        loadCss(src.css);
+        diag({ lib: 'ok (' + src.name + ')' });
+        return gl;
+      } catch (e) {
+        tried.push(src.name + ': ' + e.message);
+      }
+    }
+    throw new Error('Mapbox GL kon nergens laden — ' + tried.join(' · '));
+  })();
+  // Never cache a failure: a retry (andere stijl, opnieuw proberen) must retry.
+  mbPromise.catch(() => { mbPromise = null; });
   return mbPromise;
 }
 
@@ -102,10 +146,25 @@ function setData(map, plan, geo) {
  *   setMode(is3d)         — tilt + show/hide the draped plan layers
  *   setPlan(plan)         — refresh the plan GeoJSON
  */
-export async function initMap(container, token, geo, plan, onError, styleUrl) {
+export async function initMap(container, token, geo, plan, onError, styleUrl, onDiag) {
+  const diag = (d) => { try { if (onDiag) onDiag(d); } catch (e) {} };
+  diag({ lib: '…', webgl: '…', style: '…', tiles: 0, detail: '' });
+
+  if (!webglOk()) {
+    diag({ webgl: 'NIET BESCHIKBAAR' });
+    onError('WebGL is niet beschikbaar. Zet hardwareversnelling aan in je browser, of zet in Brave de "fingerprinting"-bescherming voor deze site op standaard — Mapbox kan zonder WebGL niet tekenen.');
+    return null;
+  }
+  diag({ webgl: 'ok' });
+
   let mapboxgl;
-  try { mapboxgl = await loadMapbox(); }
-  catch (e) { onError('Mapbox GL kon niet laden — controleer je verbinding.'); return null; }
+  try { mapboxgl = await loadMapbox(diag); }
+  catch (e) {
+    diag({ lib: 'GEBLOKKEERD', detail: e.message });
+    onError('Mapbox GL kon niet laden. Een blocker/extensie of je netwerk houdt het tegen. Details: ' + e.message);
+    return null;
+  }
+
   mapboxgl.accessToken = token;
   const style = styleUrl || 'mapbox://styles/mapbox/satellite-streets-v12';
   let map;
@@ -115,28 +174,38 @@ export async function initMap(container, token, geo, plan, onError, styleUrl) {
       center: [geo.lon, geo.lat], zoom: 17, pitch: 0, bearing: 0,
       interactive: false, antialias: true, attributionControl: false,
     });
-  } catch (e) { onError('Kaart kon niet starten: ' + e.message); return null; }
+  } catch (e) { diag({ style: 'FOUT', detail: e.message }); onError('Kaart kon niet starten: ' + e.message); return null; }
 
-  let ready = false, pending3d = false, lastPlan = plan;
-  const loadTimer = setTimeout(() => { if (!ready) onError('De kaart laadt niet — controleer je Mapbox-token en internetverbinding.'); }, 9000);
+  let ready = false, pending3d = false, lastPlan = plan, tiles = 0;
+  diag({ style: 'laden…' });
+  const loadTimer = setTimeout(() => {
+    if (ready) return;
+    diag({ style: 'TIME-OUT' });
+    onError('De kaartstijl laadt niet (time-out). Meestal blokkeert een blocker/extensie api.mapbox.com, of het token mag deze site niet gebruiken.');
+  }, 12000);
   map.on('error', (ev) => {
     const err = ev && ev.error;
     const msg = (err && err.message) || String(err || 'onbekende kaartfout');
     const status = err && err.status;
     // eslint-disable-next-line no-console
     console.warn('[ParkPlanner map]', status || '', msg);
+    diag({ detail: (status ? status + ' · ' : '') + msg });
     if (status === 401 || status === 403 || /token|unauthorized|access|forbidden/i.test(msg)) {
-      onError('Mapbox-token geweigerd (401/403). Gebruik een public token (pk.…) zonder URL-restrictie, of voeg vandenostende.github.io toe aan de toegestane URLs.');
+      diag({ style: 'TOKEN GEWEIGERD (' + (status || '401/403') + ')' });
+      onError('Mapbox-token geweigerd (' + (status || '401/403') + '). Gebruik een public token (pk.…) zonder URL-restrictie, of voeg vandenostende.github.io toe aan de toegestane URLs van het token.');
     } else if (!ready) onError('Kaartfout: ' + msg);
   });
   map.on('style.load', () => {
     ready = true;
     clearTimeout(loadTimer);
+    diag({ style: 'ok' });
     onError('');
     try { addPlanLayers(map, lastPlan, geo); } catch (e) {}
     if (pending3d) { setPlanVisible(map, true); }
     setTimeout(() => { try { map.resize(); } catch (e) {} }, 60);
   });
+  map.on('data', (e) => { if (e && e.tile) tiles++; });
+  map.on('idle', () => diag({ tiles }));
 
   return {
     map,

--- a/files/testfit/styles.css
+++ b/files/testfit/styles.css
@@ -82,6 +82,27 @@ body {
 .seg.style-seg { flex-wrap: wrap; }
 .seg.style-seg button { flex: 1 1 40%; padding: 5px 4px; font-size: 11.5px; }
 
+.map-diag {
+  margin-top: 6px;
+  padding: 7px 8px;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 11px;
+  color: var(--muted);
+}
+.map-diag > div { display: flex; justify-content: space-between; gap: 8px; padding: 1px 0; }
+.map-diag b { color: var(--text); font-weight: 600; text-align: right; }
+.map-diag .map-diag-detail {
+  display: block;
+  margin-top: 5px;
+  padding-top: 5px;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  word-break: break-word;
+  line-height: 1.4;
+}
+
 .dropdown { position: relative; }
 .dropdown .menu {
   position: absolute;


### PR DESCRIPTION
## Probleem

De kaart kon falen met **geen kaart, geen foutmelding en niets in de console**.

**Oorzaak (gereproduceerd):** `loadMapbox()` wachtte op een `<script>` dat door een blocker/extensie/proxy *stilzwijgend* kan worden opgeslokt — dan vuurt noch `onload` noch `onerror`. De promise settelde dus nooit. De enige time-out (`loadTimer`) werd pas *ná* die `await` gezet, dus die kwam nooit aan bod: init hing oneindig en er werd nooit iets gerapporteerd.

Bevestigd met instrumentatie: `initMap start` verscheen, daarna nooit `onError`, `ctrl` of de outer catch.

## Wijzigingen

**`src/map3d.js`**
- `loadScript()` heeft nu een **10s time-out**, zodat een opgeslokt request altijd settelt.
- Loader valt terug over **api.mapbox.com → unpkg → jsdelivr** (api.mapbox.com staat op sommige ad-blocker filterlijsten).
- Een mislukte load **vergiftigt de gecachte `mbPromise` niet meer** — retries proberen nu echt opnieuw (voorheen bleef een afgewezen promise voor altijd hangen, alleen een page reload hielp).
- Expliciete **WebGL-probe** met een actiegerichte melding (Brave fingerprint-shield / hardwareversnelling).
- Stijl-time-out naar 12s en gerapporteerd als aparte fase.
- Per-fase diagnostiek via een nieuwe `onDiag`-callback, incl. tegelteller en de laatste fout mét HTTP-status.

**`src/app.js`**
- Guard tegen een `null` controller — voorheen gooide `ctrl.setMode()` een TypeError die de outer catch als generieke melding maskeerde.
- `mapDiag`-state, een uitklapbare **"Kaart-diagnose"**-readout en een **"opnieuw proberen"** die de map-lifecycle herstart via een nonce.

**`styles.css`** — styling voor de `.map-diag` readout.

## Verificatie

- `node --check` op beide modules → OK.
- **Faalpad** (headless, alle CDN's geblokkeerd): voorheen oneindige stilte, nu live readout `WebGL ok | Bibliotheek laden via api.mapbox.com… | Stijl … | Tegels 0` en daarna een concrete fout die elke geprobeerde bron benoemt.
- **Regressie** met stijl "Geen": plan wordt getekend (281 niet-transparante samples), HUD toont `105 vakken · schaal 6.8 px/m · live`, geen console-errors.
- Mapbox-tiles kunnen niet renderen in de sandbox (browser komt niet door de proxy), dus het *succes*pad is hier niet visueel bevestigd — het faalpad en de fallback wel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_