### PR TITLE
ParkPlanner: report library status on the already-loaded map path

### DIFF
--- a/files/testfit/src/map3d.js
+++ b/files/testfit/src/map3d.js
@@ -54,8 +54,14 @@ function loadCss(href) {
 }
 
 function loadMapbox(diag) {
-  if (window.mapboxgl) return Promise.resolve(window.mapboxgl);
-  if (mbPromise) return mbPromise;
+  // Both early-outs must still report, or the readout is stuck on its initial
+  // placeholder while everything downstream is fine (re-init after a style
+  // switch hits this path, since the library is already in memory).
+  if (window.mapboxgl) { diag({ lib: 'ok (al geladen)' }); return Promise.resolve(window.mapboxgl); }
+  if (mbPromise) {
+    diag({ lib: 'laden…' });
+    return mbPromise.then((gl) => { diag({ lib: 'ok (al geladen)' }); return gl; });
+  }
   mbPromise = (async () => {
     const tried = [];
     for (const src of MB_SOURCES) {


### PR DESCRIPTION
## Probleem

De **Bibliotheek**-regel in de kaart-diagnose bleef op zijn beginwaarde staan zodra `mapbox-gl` al in het geheugen zat. `loadMapbox()` keerde vroeg terug op zowel het `window.mapboxgl`-pad als het in-flight `mbPromise`-pad, zonder ooit `diag()` aan te roepen.

Een her-initialisatie na een stijlwissel raakt altijd dat pad — dus een **volledig werkende kaart** rapporteerde een lege bibliotheek-fase. Dat is precies wat er in de praktijk gezien werd: `WebGL ok · Bibliotheek — · Stijl ok · Tegels 9`.

Puur een gat in de readout; de kaart zelf werkte.

## Wijziging

`src/map3d.js` — beide early-outs rapporteren nu:
- `window.mapboxgl` aanwezig → `ok (al geladen)`
- in-flight `mbPromise` → `laden…`, daarna `ok (al geladen)` bij afronding

## Verificatie

Headless reproductie van exact die situatie (mapboxgl vooraf aanwezig, style-load + 9 tegels gesimuleerd):

- **Voor:** `WebGL | ok | Bibliotheek | … | Stijl | ok | Tegels | 9`
- **Na:** `WebGL | ok | Bibliotheek | ok (al geladen) | Stijl | ok | Tegels | 9`

Geen console-errors. `node --check` op beide modules → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_