### PR TITLE
ParkPlanner: own the Mapbox canvas layout + report canvas geometry

### DIFF
--- a/files/testfit/src/app.js
+++ b/files/testfit/src/app.js
@@ -2241,6 +2241,7 @@ function App() {
                 <div><span>Bibliotheek</span><b>${mapDiag.lib || '—'}</b></div>
                 <div><span>Stijl</span><b>${mapDiag.style || '—'}</b></div>
                 <div><span>Tegels</span><b>${mapDiag.tiles == null ? '—' : mapDiag.tiles}</b></div>
+                <div><span>Canvas</span><b>${mapDiag.canvas || '—'}</b></div>
                 ${mapDiag.detail && html`<div className="map-diag-detail">${mapDiag.detail}</div>`}
               </div>`}`}
         </div>

--- a/files/testfit/src/map3d.js
+++ b/files/testfit/src/map3d.js
@@ -45,7 +45,10 @@ function loadScript(src) {
   });
 }
 
+let cssDone = false;
 function loadCss(href) {
+  if (cssDone) return;
+  cssDone = true;
   try {
     const css = document.createElement('link');
     css.rel = 'stylesheet'; css.href = href;
@@ -57,7 +60,9 @@ function loadMapbox(diag) {
   // Both early-outs must still report, or the readout is stuck on its initial
   // placeholder while everything downstream is fine (re-init after a style
   // switch hits this path, since the library is already in memory).
-  if (window.mapboxgl) { diag({ lib: 'ok (al geladen)' }); return Promise.resolve(window.mapboxgl); }
+  // Even here the stylesheet must be ensured: a re-init reuses the library but
+  // may be the first attempt at the CSS.
+  if (window.mapboxgl) { loadCss(MB_SOURCES[0].css); diag({ lib: 'ok (al geladen)' }); return Promise.resolve(window.mapboxgl); }
   if (mbPromise) {
     diag({ lib: 'laden…' });
     return mbPromise.then((gl) => { diag({ lib: 'ok (al geladen)' }); return gl; });
@@ -201,17 +206,30 @@ export async function initMap(container, token, geo, plan, onError, styleUrl, on
       onError('Mapbox-token geweigerd (' + (status || '401/403') + '). Gebruik een public token (pk.…) zonder URL-restrictie, of voeg vandenostende.github.io toe aan de toegestane URLs van het token.');
     } else if (!ready) onError('Kaartfout: ' + msg);
   });
+  // What actually ended up on screen — the missing link when tiles load fine
+  // but nothing is visible.
+  const reportCanvas = () => {
+    try {
+      const c = container.querySelector('canvas');
+      if (!c) { diag({ canvas: 'GEEN CANVAS' }); return; }
+      const r = c.getBoundingClientRect();
+      const cs = getComputedStyle(c);
+      diag({ canvas: Math.round(r.width) + '×' + Math.round(r.height) + ' · ' + cs.position + ' · opacity ' + cs.opacity + (r.width < 50 || r.height < 50 ? ' ⚠️' : '') });
+    } catch (e) {}
+  };
+
   map.on('style.load', () => {
     ready = true;
     clearTimeout(loadTimer);
     diag({ style: 'ok' });
+    setTimeout(reportCanvas, 120);
     onError('');
     try { addPlanLayers(map, lastPlan, geo); } catch (e) {}
     if (pending3d) { setPlanVisible(map, true); }
     setTimeout(() => { try { map.resize(); } catch (e) {} }, 60);
   });
   map.on('data', (e) => { if (e && e.tile) tiles++; });
-  map.on('idle', () => diag({ tiles }));
+  map.on('idle', () => { diag({ tiles }); reportCanvas(); });
 
   return {
     map,

--- a/files/testfit/styles.css
+++ b/files/testfit/styles.css
@@ -222,6 +222,12 @@ canvas { display: block; touch-action: none; }
 /* ---- 3D (Mapbox) ---- */
 .map3d { position: absolute; inset: 0; z-index: 5; }
 .pp-map { position: absolute; inset: 0; z-index: 0; }
+/* Mapbox's own stylesheet positions its canvas; if it is blocked or missing the
+   map loads tiles but paints nothing visible. Own the layout ourselves so the
+   basemap renders regardless of whether mapbox-gl.css ever arrives. */
+.pp-map .mapboxgl-map { position: relative; width: 100%; height: 100%; overflow: hidden; }
+.pp-map .mapboxgl-canvas-container { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
+.pp-map .mapboxgl-canvas { position: absolute; top: 0; left: 0; }
 .canvas-wrap > canvas { position: relative; z-index: 1; }
 .token-panel { z-index: 6; }
 .token-panel {


### PR DESCRIPTION
## Probleem

De kaart-diagnose meldt `Stijl ok` en `Tegels 9` — en 9 tegels is **exact correct** voor een 770×634 viewport op z≈19 met 512px-tegels. De kaartmotor draait dus goed, op de juiste locatie en zoom. Toch is er niets te zien.

Uitgesloten door de code te lezen:
- Het plan-canvas is in 2D écht transparant (`clearRect` + een site-fill van 5% alpha). De twee full-canvas fills die er staan, horen bij de 2.5D/3D-paden.
- `#pp-map` staat correct in `.canvas-wrap`, `z-index: 0` onder het canvas op `z-index: 1`.

Wat overblijft: Mapbox' eigen canvas wordt niet getoond. Mapbox leunt op `mapbox-gl.css` om dat canvas te positioneren — zonder die stylesheet laadt de kaart vrolijk tegels maar tekent hij niets zichtbaars.

En daar zat een echt gat: de "al geladen"-tak van `loadMapbox()` keerde vroeg terug **zonder ooit de stylesheet op te vragen**. Elke her-init (dus elke stijlwissel) kon zonder CSS draaien.

## Wijzigingen

- **`styles.css`** — layout van `.mapboxgl-map` / `-canvas-container` / `-canvas` onder `.pp-map` zelf in handen nemen, zodat de basemap rendert ongeacht of `mapbox-gl.css` ooit aankomt.
- **`src/map3d.js`** — stylesheet ook garanderen op het al-geladen pad, ontdubbeld via een `cssDone`-vlag. Nieuwe `reportCanvas()`-diagnostiek die de gerenderde grootte, `position` en `opacity` van het Mapbox-canvas rapporteert op `style.load` en op `idle`, zodat een "laadt wel, ziet niets"-kaart direct waarneembaar is.
- **`src/app.js`** — `Canvas`-regel toegevoegd aan de readout.

## Verificatie

Headless reproductie van een Mapbox-DOM **zonder** zijn stylesheet:

```
WebGL ok | Bibliotheek ok (al geladen) | Stijl ok | Tegels 9 | Canvas 1540×1268 · absolute · opacity 1
```

Het canvas krijgt nu `position: absolute` uit onze eigen regels in plaats van uit de ontbrekende Mapbox-CSS. Geen console-errors. `node --check` op beide modules → OK.

**Eerlijke kanttekening:** dat de ontbrekende CSS de daadwerkelijke oorzaak is, is hiermee niet bewezen — echte Mapbox-tiles kunnen niet renderen in de sandbox. Deze PR maakt de layout onafhankelijk van die stylesheet én maakt de uitkomst meetbaar via de `Canvas`-regel, zodat een volgende meting uitsluitsel geeft in plaats van een gok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_