### PR TITLE
ParkPlanner: re-measure the Mapbox container so the basemap fills it

### DIFF
--- a/files/testfit/src/map3d.js
+++ b/files/testfit/src/map3d.js
@@ -213,10 +213,29 @@ export async function initMap(container, token, geo, plan, onError, styleUrl, on
       const c = container.querySelector('canvas');
       if (!c) { diag({ canvas: 'GEEN CANVAS' }); return; }
       const r = c.getBoundingClientRect();
-      const cs = getComputedStyle(c);
-      diag({ canvas: Math.round(r.width) + '×' + Math.round(r.height) + ' · ' + cs.position + ' · opacity ' + cs.opacity + (r.width < 50 || r.height < 50 ? ' ⚠️' : '') });
+      const box = container.getBoundingClientRect();
+      // A canvas smaller than its container means Mapbox is holding a stale
+      // measurement — it renders a sliver and the rest stays empty.
+      const stale = Math.abs(r.height - box.height) > 4 || Math.abs(r.width - box.width) > 4;
+      diag({ canvas: Math.round(r.width) + '×' + Math.round(r.height) + ' · vak ' + Math.round(box.width) + '×' + Math.round(box.height) + (stale ? ' ⚠️ mismatch' : ' ok') });
     } catch (e) {}
   };
+
+  // Mapbox measures its container once at construction and never re-checks on
+  // its own. If the grid row had not settled yet it locks in a wrong height
+  // (e.g. 300px) and paints only a sliver, hidden behind the plan canvas.
+  // Track the container so every layout change re-measures.
+  let ro = null;
+  try {
+    ro = new ResizeObserver(() => {
+      try { map.resize(); } catch (e) {}
+      reportCanvas();
+    });
+    ro.observe(container);
+  } catch (e) {}
+  // Belt and braces for browsers/layouts where the observer fires before the
+  // final box is known.
+  [0, 150, 500, 1200].forEach((t) => setTimeout(() => { try { map.resize(); } catch (e) {} }, t));
 
   map.on('style.load', () => {
     ready = true;
@@ -248,6 +267,6 @@ export async function initMap(container, token, geo, plan, onError, styleUrl, on
     setPlan(p) { lastPlan = p; try { setData(map, p, geo); } catch (e) {} },
     resize() { try { map.resize(); } catch (e) {} },
     recenter(g) { try { map.jumpTo({ center: [g.lon, g.lat] }); } catch (e) {} },
-    destroy() { try { map.remove(); } catch (e) {} },
+    destroy() { try { if (ro) ro.disconnect(); } catch (e) {} try { map.remove(); } catch (e) {} },
   };
 }

--- a/files/testfit/styles.css
+++ b/files/testfit/styles.css
@@ -225,7 +225,8 @@ canvas { display: block; touch-action: none; }
 /* Mapbox's own stylesheet positions its canvas; if it is blocked or missing the
    map loads tiles but paints nothing visible. Own the layout ourselves so the
    basemap renders regardless of whether mapbox-gl.css ever arrives. */
-.pp-map .mapboxgl-map { position: relative; width: 100%; height: 100%; overflow: hidden; }
+/* Mapbox puts .mapboxgl-map on the container element itself, not on a child. */
+.pp-map.mapboxgl-map { position: absolute; overflow: hidden; }
 .pp-map .mapboxgl-canvas-container { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
 .pp-map .mapboxgl-canvas { position: absolute; top: 0; left: 0; }
 .canvas-wrap > canvas { position: relative; z-index: 1; }


### PR DESCRIPTION
## Oorzaak gevonden

De `Canvas`-regel uit de vorige PR wees het exact aan:

```
Canvas   1170×300      ← kaartgebied is ~950px hoog
```

Mapbox meet zijn container **één keer** bij aanmaak en controleert daarna nooit meer. Toen de grid-rij nog niet uitgerekend was, legde hij een hoogte van 300px vast, tekende een strookje bovenaan — en dat strookje viel volledig achter het plan-canvas. Vandaar: tegels laden, stijl `ok`, en toch niets zichtbaar.

De bestaande `resize()`-aanroepen op 100ms vuurden vóór de layout definitief was.

## Wijzigingen

- **`src/map3d.js`** — container volgen met een `ResizeObserver` die bij elke box-wijziging `map.resize()` aanroept (netjes losgekoppeld in `destroy()`), plus extra resizes op 0/150/500/1200ms voor layouts die ná de eerste observer-fire pas uitzakken.
- **`src/map3d.js`** — `reportCanvas()` vergelijkt het canvas nu mét zijn container en markeert een mismatch, zodat een verouderde meting zichtbaar is in plaats van afgeleid.
- **`styles.css`** — `.mapboxgl-map` komt op het container-element zélf te staan, niet op een kind. De regel moet dus `.pp-map.mapboxgl-map` zijn; de descendant-selector uit de vorige PR matchte niets.

## Verificatie

Het exacte faalgeval nagebouwd (canvas vastgezet op 1170×300, container 1390×1051):

- **Voor:** `Canvas 1170×300`
- **Na:** `Canvas 1390×1051 · vak 1390×1051 ok`

De observer corrigeert de verouderde meting naar de volle container en de readout klapt van mismatch naar `ok`. Geen console-errors. `node --check` op beide modules → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk1oN9XYt7dMqHKbbBCVoq)_